### PR TITLE
fix Java 8 compile errors

### DIFF
--- a/src/test/java/org/cloudfoundry/credhub/helper/JsonTestHelper.java
+++ b/src/test/java/org/cloudfoundry/credhub/helper/JsonTestHelper.java
@@ -89,11 +89,11 @@ public class JsonTestHelper {
     }
   }
 
-  public static Matcher<ConstraintViolation> hasViolationWithMessage(String expectedMessage) {
-    return new BaseMatcher<ConstraintViolation>() {
+  public static Matcher<ConstraintViolation<?>> hasViolationWithMessage(String expectedMessage) {
+    return new BaseMatcher<ConstraintViolation<?>>() {
       @Override
       public boolean matches(final Object item) {
-        final ConstraintViolation violation = (ConstraintViolation) item;
+        final ConstraintViolation<?> violation = (ConstraintViolation<?>) item;
         return violation.getMessage().equals(expectedMessage);
       }
 


### PR DESCRIPTION
Without those changes I got compile errors in Eclipse with Java 8.

One of those errors:

`The method assertThat(T, Matcher<? super T>) in the type MatcherAssert is not applicable for the arguments (Set<ConstraintViolation<CertificateSetRequest>>, Matcher<Iterable<? super ConstraintViolation>>)	CertificateSetRequestTest.java	/credhub/src/test/java/org/cloudfoundry/credhub/request	line 171
`