### PR TITLE
[solution open for discussion] Fix error on PKCS8 keys

### DIFF
--- a/src/main/java/org/cloudfoundry/credhub/util/PrivateKeyReader.java
+++ b/src/main/java/org/cloudfoundry/credhub/util/PrivateKeyReader.java
@@ -13,16 +13,33 @@ import java.security.PublicKey;
 
 public class PrivateKeyReader {
 
-  public static PrivateKey getPrivateKey(String privateKeyPem) throws IOException {
+    public static class UnsupportedFormatException extends Exception {
+        private static final long serialVersionUID = -2669429797326574839L;
+        public UnsupportedFormatException(String msg) {
+            super(msg);
+        }
+    }
+
+  public static PrivateKey getPrivateKey(String privateKeyPem) throws IOException, UnsupportedFormatException {
     PEMParser pemParser = new PEMParser(new StringReader(privateKeyPem));
-    PEMKeyPair pemKeyPair = (PEMKeyPair) pemParser.readObject();
+    Object parsed = pemParser.readObject();
+    pemParser.close();
+    if (!(parsed instanceof PEMKeyPair)) {
+      throw new UnsupportedFormatException("format of private key is not supported.");
+    }
+    PEMKeyPair pemKeyPair = (PEMKeyPair) parsed;
     PrivateKeyInfo privateKeyInfo = pemKeyPair.getPrivateKeyInfo();
     return new JcaPEMKeyConverter().getPrivateKey(privateKeyInfo);
   }
 
-  public static PublicKey getPublicKey(String privateKeyPem) throws IOException {
+  public static PublicKey getPublicKey(String privateKeyPem) throws IOException, UnsupportedFormatException {
     PEMParser pemParser = new PEMParser(new StringReader(privateKeyPem));
-    PEMKeyPair pemKeyPair = (PEMKeyPair) pemParser.readObject();
+    Object parsed = pemParser.readObject();
+    pemParser.close();
+    if (!(parsed instanceof PEMKeyPair)) {
+      throw new UnsupportedFormatException("format of private key is not supported.");
+    }
+    PEMKeyPair pemKeyPair = (PEMKeyPair) parsed;
     SubjectPublicKeyInfo publicKeyInfo = pemKeyPair.getPublicKeyInfo();
     return new JcaPEMKeyConverter().getPublicKey(publicKeyInfo);
   }

--- a/src/main/java/org/cloudfoundry/credhub/validator/CertificateMatchesPrivateKeyValidator.java
+++ b/src/main/java/org/cloudfoundry/credhub/validator/CertificateMatchesPrivateKeyValidator.java
@@ -1,7 +1,9 @@
 package org.cloudfoundry.credhub.validator;
 
+import org.cloudfoundry.credhub.exceptions.ParameterizedValidationException;
 import org.cloudfoundry.credhub.util.CertificateReader;
 import org.cloudfoundry.credhub.util.PrivateKeyReader;
+import org.cloudfoundry.credhub.util.PrivateKeyReader.UnsupportedFormatException;
 import org.apache.commons.lang3.StringUtils;
 
 import java.lang.reflect.Field;
@@ -44,6 +46,8 @@ public class CertificateMatchesPrivateKeyValidator implements ConstraintValidato
       final PublicKey publicKey = PrivateKeyReader.getPublicKey(privateKeyValue);
 
       return publicKey.equals(certificatePublicKey);
+    } catch (UnsupportedFormatException e) {
+      throw new ParameterizedValidationException("error.invalid_key_format", e.getMessage());
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -27,6 +27,7 @@ error.invalid_duration=Invalid duration specified. The supported duration values
 error.invalid_json_key=The request includes an unrecognized parameter ''{0}''. Please update or remove this parameter and retry your request.
 error.invalid_key_length=The provided key length is not supported. Valid values include '2048', '3072' and '4096'.
 error.invalid_token_signature=The request token signature could not be verified. Please validate that your request token was issued by the UAA server authorized by CredHub.
+error.invalid_key_format=The provided key format is not supported.
 error.mismatched_certificate_and_private_key=The provided certificate does not match the private key.
 error.missing_certificate_credentials=At least one certificate attribute must be set. Please validate your input and retry your request.
 error.missing_certificate_parameters=At least one subject value, such as common name or organization, must be defined to generate the certificate. Please update and retry your request.

--- a/src/test/java/org/cloudfoundry/credhub/helper/JsonTestHelper.java
+++ b/src/test/java/org/cloudfoundry/credhub/helper/JsonTestHelper.java
@@ -89,11 +89,11 @@ public class JsonTestHelper {
     }
   }
 
-  public static Matcher<ConstraintViolation> hasViolationWithMessage(String expectedMessage) {
-    return new BaseMatcher<ConstraintViolation>() {
+  public static Matcher<ConstraintViolation<?>> hasViolationWithMessage(String expectedMessage) {
+    return new BaseMatcher<ConstraintViolation<?>>() {
       @Override
       public boolean matches(final Object item) {
-        final ConstraintViolation violation = (ConstraintViolation) item;
+        final ConstraintViolation<?> violation = (ConstraintViolation<?>) item;
         return violation.getMessage().equals(expectedMessage);
       }
 

--- a/src/test/java/org/cloudfoundry/credhub/integration/CertificateSetAndRegenerateTest.java
+++ b/src/test/java/org/cloudfoundry/credhub/integration/CertificateSetAndRegenerateTest.java
@@ -33,6 +33,7 @@ import static org.cloudfoundry.credhub.util.AuthConstants.UAA_OAUTH2_PASSWORD_GR
 import static org.cloudfoundry.credhub.util.TestConstants.TEST_CA;
 import static org.cloudfoundry.credhub.util.TestConstants.TEST_CERTIFICATE;
 import static org.cloudfoundry.credhub.util.TestConstants.TEST_PRIVATE_KEY;
+import static org.cloudfoundry.credhub.util.TestConstants.TEST_PRIVATE_KEY_PKCS8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertNotNull;
@@ -480,4 +481,23 @@ public class CertificateSetAndRegenerateTest {
     this.mockMvc.perform(certificateSetRequest)
         .andExpect(status().isBadRequest());
   }
+
+  @Test
+  public void certificateSetRequest_withInvalidKey_shouldReturnBadRequest() throws Exception {
+    final String setJson = JSONObject.toJSONString(
+        ImmutableMap.<String, String>builder()
+            .put("certificate", TEST_CERTIFICATE)
+            .put("private_key", TEST_PRIVATE_KEY_PKCS8)
+            .build());
+
+    MockHttpServletRequestBuilder certificateSetRequest = post("/api/v1/certificates/" + caCredentialUuid + "/versions")
+        .header("Authorization", "Bearer " + UAA_OAUTH2_PASSWORD_GRANT_TOKEN)
+        .accept(APPLICATION_JSON)
+        .contentType(APPLICATION_JSON)
+        .content("{\"value\" : " + setJson + "}");
+
+    this.mockMvc.perform(certificateSetRequest)
+        .andExpect(status().isBadRequest());
+  }
+
 }

--- a/src/test/java/org/cloudfoundry/credhub/util/TestConstants.java
+++ b/src/test/java/org/cloudfoundry/credhub/util/TestConstants.java
@@ -161,4 +161,32 @@ public class TestConstants {
       "OlKeNTSxn9AkyYx9PJ8i1TIx6GyFIX4pkJczLEu+XINm82MKSBGuRL1EUvkVddx3\n" +
       "6clZk5BLDXjmCtCr5DGZ01EbT0wsbsBM1GtoCS4+vUQkJVHb0r6/ZdM=\n" +
       "-----END RSA PRIVATE KEY-----";
+  public static String TEST_PRIVATE_KEY_PKCS8 = "-----BEGIN PRIVATE KEY-----\n" +
+      "MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDCoitXwekK4/K4\n" +
+      "npW/IbuBWFgkYA5fjOFyXGRMApPmuQTgt+PTjwZmwOCEr6kez61Wi1/KsnNgYmgQ\n" +
+      "FOf1bLuQ/mlCYtEXniKYPO16nXk6XKgmYtl9GBy3/wrLGSOCDc8pXDrwiI2GdOVh\n" +
+      "rDgIDJn/Xea/DZxYhiVqD0tXlHaJ9zK5tpiWXEmF1ZJetxtjGu2zWRGxRBOj32Mn\n" +
+      "Mq7vWZ4uKAyvJoyvLzG+O/VfxiOrezcu53qBZnoG5pppVUiMj1yUaBHUySAomBWR\n" +
+      "aM3MNGILFierUscKGj1uAqCJjinrTjM+T0zDgWG0Js6Kboc6wdOKY41ld8M2Z+wn\n" +
+      "3Al58DRTAgMBAAECggEATCxNzEW+4B1AVFL0hl48VS3vKSVS2sB3R1uzgTANFGJa\n" +
+      "71vo1VaHidV4yVU6Wi2rSFC5x8m5cAJzeb/E3H+WlPOM3IdyD806+tv1kWRqGpZC\n" +
+      "1Osg9V1nd/dgEQagp/ihmC1Zf+Phh7rePzC4qSXNa20jrqg0BU1S/URJF1iqX+nn\n" +
+      "8FVIlpUrht2RepgdfaPc+s93fQgLDHPRsZ3jVR0yIowmGWSEgRKwHxtx1EARoxLY\n" +
+      "5oUqYFghAXhG5jezK8WLMkO2n9ARh+PL21NeiR3dbOzp2dyf/LJ+9PT7IIONiw0C\n" +
+      "AW8GZ8c0GivLDEgt22Ake5z2g7YQ56DnxUpW3h66AQKBgQD/DFvb2lVqbDEXvWAr\n" +
+      "H+awFrmTDFXk3s2FMt1jIfCFBUStCXCfsOAnyot9mqafbfXKgakotmy7abF1G+l3\n" +
+      "2e86Jb5kX5+ytLxISzl0wSqGiMAubyu6v5jkzT9KT8DSUJtKZX5fu+apobPI12Af\n" +
+      "u1hUjFeMCjiwRg3oZ6+NQHUlAQKBgQDDXBkGGGwi9b2B9u4J2JMaV7NS4g7ejGO9\n" +
+      "JJM1RoYAHsZSoHbq2gGdeLqhCLmIa790JhTcIgs6RXuRNf//aeM59Yun+Q/7mdUo\n" +
+      "OAegD/SAvrT2yCt2CRDQp1neK66uKZ6q8OZTmGk+s1zDPvI8n8zTzW97zikerfDN\n" +
+      "UqmLV0w1UwKBgQDh7knFNODreFH4zKpPKWBKZqcXaxr/tprqvoc9FMiinWsbubwJ\n" +
+      "yj6XISZ2KrQlkNvl+vwlc4xYbKVlr0cfA3CW2u6QreCjBtWvWOvZ0G/iY2uS9qoP\n" +
+      "MUC4llTVeFbAN+WIfuX22lXXuMWxSZD+KxBxPS0kgb178WLKmGb7wrjDAQKBgQDB\n" +
+      "dsIdRDBKirtqKiRfQcejrbgbW1zITZU0KTVS7A0lr1RNXTWGq/AvhvCjKqW5kKKf\n" +
+      "nlrICTq/MTIGgsiKoszwh9cOuFp4mkX6N0pt238RxEonneFUWfP5/dDEcNPjC7pi\n" +
+      "pIAjxupqumshu4NeQA4yrd46Z9ZW2ICAhNz77a69mwKBgQCak3ZF8fE7eG4RYWgT\n" +
+      "stPL1ZO/gMMcj6Dw94JSk/ak39SZzMifJDg6Up41NLGf0CTJjH08nyLVMjHobIUh\n" +
+      "fimQlzMsS75cg2bzYwpIEa5EvURS+RV13HfpyVmTkEsNeOYK0KvkMZnTURtPTCxu\n" +
+      "wEzUa2gJLj69RCQlUdvSvr9l0w==\n" +
+      "-----END PRIVATE KEY-----";
 }


### PR DESCRIPTION
Hi,

we noticed that trying to create a certificate object with a private key in PKCS8 format results in a 500 response "An application error occurred. Please contact your CredHub administrator".

On the server side an exception is thrown:
```
javax.validation.ValidationException: HV000028: Unexpected exception during isValid call.
	at org.hibernate.validator.internal.engine.constraintvalidation.ConstraintTree.validateSingleConstraint(ConstraintTree.java:451) ~[hibernate-validator-5.3.6.Final.jar:5.3.6.Final]
	at org.hibernate.validator.internal.engine.constraintvalidation.ConstraintTree.validateConstraints(ConstraintTree.java:127) ~[hibernate-validator-5.3.6.Final.jar:5.3.6.Final]
...
Caused by: java.lang.ClassCastException: org.bouncycastle.asn1.pkcs.PrivateKeyInfo cannot be cast to org.bouncycastle.openssl.PEMKeyPair
	at org.cloudfoundry.credhub.util.PrivateKeyReader.getPublicKey(PrivateKeyReader.java:42) ~[bin/:?]
```

This pull request fixes the error and returns a "The provided key format is not supported." response.

However I am unsure if we want to support PKCS8 key format instead of returning an error. Whats your opinion?

Best regards,
Jürgen