### PR TITLE
Add secretKeyMode to password generation

### DIFF
--- a/src/main/java/org/cloudfoundry/credhub/generator/PasswordCredentialGenerator.java
+++ b/src/main/java/org/cloudfoundry/credhub/generator/PasswordCredentialGenerator.java
@@ -1,10 +1,15 @@
 package org.cloudfoundry.credhub.generator;
 
+import org.apache.commons.codec.binary.Base64;
 import org.cloudfoundry.credhub.credential.StringCredentialValue;
 import org.cloudfoundry.credhub.request.GenerationParameters;
 import org.cloudfoundry.credhub.request.StringGenerationParameters;
+import org.cloudfoundry.credhub.util.SecretKeyHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+import java.util.Random;
 
 // Can't be named PasswordGenerator or Spring won't know how to autowire it.
 @Component
@@ -19,6 +24,13 @@ public class PasswordCredentialGenerator implements CredentialGenerator<StringCr
 
   @Override
   public StringCredentialValue generateCredential(GenerationParameters stringGenerationParameters) {
-    return passayStringCredentialGenerator.generateCredential((StringGenerationParameters) stringGenerationParameters);
+    StringGenerationParameters parameters = (StringGenerationParameters) stringGenerationParameters;
+
+    if (parameters.isSecretKeyMode()) {
+      String secretKey = SecretKeyHelper.generateSecretKey(parameters.getLength());
+      return new StringCredentialValue(secretKey);
+    }
+
+    return passayStringCredentialGenerator.generateCredential(parameters);
   }
 }

--- a/src/main/java/org/cloudfoundry/credhub/request/StringGenerationParameters.java
+++ b/src/main/java/org/cloudfoundry/credhub/request/StringGenerationParameters.java
@@ -24,6 +24,7 @@ public class StringGenerationParameters implements GenerationParameters{
   private boolean excludeNumber;
   private boolean excludeUpper;
   private boolean includeSpecial;
+  private boolean secretKeyMode;
 
   public int getLength() {
     return length;
@@ -40,6 +41,13 @@ public class StringGenerationParameters implements GenerationParameters{
 
   public StringGenerationParameters setUsername(String username) {
     this.username = username;
+    return this;
+  }
+
+  public boolean isSecretKeyMode() { return secretKeyMode; }
+
+  public StringGenerationParameters setSecretKeyMode(boolean secretKeyMode) {
+    this.secretKeyMode = secretKeyMode;
     return this;
   }
 
@@ -103,19 +111,21 @@ public class StringGenerationParameters implements GenerationParameters{
         excludeNumber == that.excludeNumber &&
         excludeUpper == that.excludeUpper &&
         includeSpecial == that.includeSpecial &&
+        Objects.equals(secretKeyMode, that.secretKeyMode) &&
         Objects.equals(length, that.length) &&
         Objects.equals(username, that.username);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(length, username, excludeLower, excludeNumber, excludeUpper, includeSpecial);
+    return Objects.hash(length, secretKeyMode, username, excludeLower, excludeNumber, excludeUpper, includeSpecial);
   }
 
   public boolean passwordOptionsEqual(StringGenerationParameters that) {
     return excludeLower == that.excludeLower &&
         excludeNumber == that.excludeNumber &&
         excludeUpper == that.excludeUpper &&
-        includeSpecial == that.includeSpecial;
+        includeSpecial == that.includeSpecial &&
+        secretKeyMode == that.secretKeyMode;
   }
 }

--- a/src/main/java/org/cloudfoundry/credhub/util/SecretKeyHelper.java
+++ b/src/main/java/org/cloudfoundry/credhub/util/SecretKeyHelper.java
@@ -1,0 +1,24 @@
+package org.cloudfoundry.credhub.util;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringUtils;
+import org.cloudfoundry.credhub.entity.RsaCredentialVersionData;
+
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Random;
+
+public class SecretKeyHelper {
+  public static String generateSecretKey(int length) {
+    Random random = new SecureRandom();
+
+    byte[] data = new byte[length];
+    random.nextBytes(data);
+
+    return new String(Base64.encodeBase64(data));
+  }
+}

--- a/src/test/java/org/cloudfoundry/credhub/domain/PasswordCredentialVersionTest.java
+++ b/src/test/java/org/cloudfoundry/credhub/domain/PasswordCredentialVersionTest.java
@@ -51,6 +51,7 @@ public class PasswordCredentialVersionTest {
 
     generationParameters = new StringGenerationParameters()
         .setExcludeLower(true)
+        .setSecretKeyMode(true)
         .setLength(10);
 
     String generationParametersJson = new JsonObjectMapper().writeValueAsString(generationParameters);
@@ -58,8 +59,7 @@ public class PasswordCredentialVersionTest {
     when(encryptor.encrypt(null))
         .thenReturn(new EncryptedValue(canaryUuid, "", ""));
     final EncryptedValue encryption = new EncryptedValue(canaryUuid, encryptedValue, nonce);
-    when(encryptor.encrypt(PASSWORD))
-        .thenReturn(encryption);
+    when(encryptor.encrypt(PASSWORD)).thenReturn(encryption);
     final EncryptedValue parametersEncryption = new EncryptedValue(canaryUuid, encryptedParametersValue, parametersNonce);
     when(encryptor.encrypt(eq(generationParametersJson)))
         .thenReturn(parametersEncryption);
@@ -81,7 +81,7 @@ public class PasswordCredentialVersionTest {
 
   @Test
   public void getGenerationParameters_shouldCallDecryptTwice() {
-    subject.setPasswordAndGenerationParameters(PASSWORD, new StringGenerationParameters().setExcludeLower(true));
+    subject.setPasswordAndGenerationParameters(PASSWORD, new StringGenerationParameters().setExcludeLower(true).setSecretKeyMode(true));
 
     subject.getGenerationParameters();
 
@@ -117,6 +117,7 @@ public class PasswordCredentialVersionTest {
     MatcherAssert.assertThat(subject.getGenerationParameters().getLength(), equalTo(11));
     MatcherAssert.assertThat(subject.getGenerationParameters().isExcludeLower(), equalTo(true));
     MatcherAssert.assertThat(subject.getGenerationParameters().isExcludeUpper(), equalTo(false));
+    MatcherAssert.assertThat(subject.getGenerationParameters().isSecretKeyMode(), equalTo(true));
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -141,7 +142,7 @@ public class PasswordCredentialVersionTest {
   @Test
   public void setPasswordAndGenerationParameters_shouldSaveGenerationParams_AsSnakeCaseJson() {
     subject.setPasswordAndGenerationParameters(PASSWORD, generationParameters);
-    String expectedJsonString = "{\"exclude_lower\":true}";
+    String expectedJsonString = "{\"exclude_lower\":true,\"secret_key_mode\":true}";
     verify(encryptor, times(1)).encrypt(expectedJsonString);
   }
 }

--- a/src/test/java/org/cloudfoundry/credhub/generator/PasswordGeneratorTest.java
+++ b/src/test/java/org/cloudfoundry/credhub/generator/PasswordGeneratorTest.java
@@ -8,6 +8,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.Random;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/org/cloudfoundry/credhub/generator/UsernameGeneratorTest.java
+++ b/src/test/java/org/cloudfoundry/credhub/generator/UsernameGeneratorTest.java
@@ -54,5 +54,6 @@ public class UsernameGeneratorTest {
     assertThat(actual.isExcludeUpper(), equalTo(false));
     assertThat(actual.isExcludeNumber(), equalTo(true));
     assertThat(actual.isIncludeSpecial(), equalTo(false));
+    assertThat(actual.isSecretKeyMode(), equalTo(false));
   }
 }

--- a/src/test/java/org/cloudfoundry/credhub/handler/GenerateHandlerTest.java
+++ b/src/test/java/org/cloudfoundry/credhub/handler/GenerateHandlerTest.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -51,7 +50,6 @@ public class GenerateHandlerTest {
     credentialVersion = mock(PasswordCredentialVersion.class);
     when(credentialService.save(anyObject(), anyObject(), anyObject(), anyList())).thenReturn(credentialVersion);
   }
-
 
   @Test
   public void handleGenerateRequest_whenPasswordGenerateRequest_passesCorrectParametersIncludingGeneration() {


### PR DESCRIPTION
Signed-off-by: Amanda Alvarez <amanda.alvarez@emc.com>

This is our first attempt at this, so we would appreciate feedback on how to improve our contribution.
We would like Credhub to generate a secret key in Base64 with the following format:
```
---
variables:
- name: /some-secret
  type: password
  options:
    length: 40 # this length will be byte length when secret_key_mode is on
    secret_key_mode: true
```
We modified some of the tests, and all tests passed.


