### PR TITLE
Increase the limit for SAN in certificate parameters

### DIFF
--- a/src/main/java/org/cloudfoundry/credhub/request/CertificateGenerationRequestParameters.java
+++ b/src/main/java/org/cloudfoundry/credhub/request/CertificateGenerationRequestParameters.java
@@ -256,7 +256,7 @@ public class CertificateGenerationRequestParameters {
     validateParameterLength(locality, "locality", 128);
     validateParameterLength(state, "state", 128);
     validateParameterLength(country, "country", 2);
-    validateParameterLength(alternativeNames, "alternative name", 64);
+    validateParameterLength(alternativeNames, "alternative name", 253);
   }
 
   private static void validateParameterLength(String[] parameterArray, String parameterName, int parameterLength) {

--- a/src/test/java/org/cloudfoundry/credhub/request/CertificateGenerationRequestParametersTest.java
+++ b/src/test/java/org/cloudfoundry/credhub/request/CertificateGenerationRequestParametersTest.java
@@ -1,5 +1,6 @@
 package org.cloudfoundry.credhub.request;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.cloudfoundry.credhub.exceptions.ParameterizedValidationException;
 import org.junit.Before;
 import org.junit.Test;
@@ -336,11 +337,11 @@ public class CertificateGenerationRequestParametersTest {
 
   @Test
   public void validate_rejectsAlternativeNamesThatAreTooLong() {
-    String maxLengthAlternativeName = "64abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz012345.com";
+    String maxLengthAlternativeName = "*." + RandomStringUtils.randomAlphabetic(100) + "." + RandomStringUtils.randomNumeric(100) + ".local";
     subject.setAlternativeNames(new String[]{"abc.com", maxLengthAlternativeName});
     subject.validate();
 
-    String overlyLongAlternativeName = "65_abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz012345.com";
+    String overlyLongAlternativeName = "*." + RandomStringUtils.randomAlphabetic(400) + ".com";
     subject.setAlternativeNames(new String[]{"abc.com", overlyLongAlternativeName});
 
     try {
@@ -348,7 +349,7 @@ public class CertificateGenerationRequestParametersTest {
       fail("should throw");
     } catch (ParameterizedValidationException e) {
       assertThat(e.getMessage(), equalTo("error.credential.invalid_certificate_parameter"));
-      assertThat(e.getParameters(), equalTo(new Object[]{"alternative name", 64}));
+      assertThat(e.getParameters(), equalTo(new Object[]{"alternative name", 253}));
     }
   }
 }


### PR DESCRIPTION
 - previously the limit was 64, but longer names are needed to support using bosh dns names
 - dns names are limited to 253 characteres
 - reference: https://tools.ietf.org/html/rfc1034

cc: @GarimaSharma