### PR TITLE
Support all valid JSON

### DIFF
--- a/src/main/java/org/cloudfoundry/credhub/credential/JsonCredentialValue.java
+++ b/src/main/java/org/cloudfoundry/credhub/credential/JsonCredentialValue.java
@@ -2,21 +2,23 @@ package org.cloudfoundry.credhub.credential;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.databind.JsonNode;
 
-import javax.validation.constraints.NotEmpty;
-import java.util.Map;
+import javax.validation.constraints.NotNull;
 
+@JsonAutoDetect
 public class JsonCredentialValue implements CredentialValue {
-  @NotEmpty(message = "error.missing_value")
-  private final Map<String, Object> value;
+  @NotNull(message = "error.missing_value")
+  private final JsonNode value;
 
   @JsonCreator
-  public JsonCredentialValue(Map<String, Object> json) {
+  public JsonCredentialValue(JsonNode json) {
     this.value = json;
   }
 
   @JsonValue
-  public Map<String, Object> getValue() {
+  public JsonNode getValue() {
     return value;
   }
 }

--- a/src/main/java/org/cloudfoundry/credhub/domain/JsonCredentialVersion.java
+++ b/src/main/java/org/cloudfoundry/credhub/domain/JsonCredentialVersion.java
@@ -1,6 +1,7 @@
 package org.cloudfoundry.credhub.domain;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.cloudfoundry.credhub.credential.JsonCredentialValue;
 import org.cloudfoundry.credhub.entity.JsonCredentialVersionData;
 import org.cloudfoundry.credhub.exceptions.ParameterizedValidationException;
@@ -8,7 +9,6 @@ import org.cloudfoundry.credhub.request.GenerationParameters;
 import org.cloudfoundry.credhub.util.JsonObjectMapper;
 
 import java.io.IOException;
-import java.util.Map;
 
 public class JsonCredentialVersion extends CredentialVersion<JsonCredentialVersion> {
 
@@ -47,14 +47,14 @@ public class JsonCredentialVersion extends CredentialVersion<JsonCredentialVersi
 
   @Override
   public void rotate() {
-    Map<String, Object> value = this.getValue();
+    JsonNode value = this.getValue();
     this.setValue(value);
   }
 
-  public Map<String, Object> getValue() {
+  public JsonNode getValue() {
     String serializedValue = (String) super.getValue();
     try {
-      return objectMapper.readValue(serializedValue, Map.class);
+      return objectMapper.readTree(serializedValue);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -68,7 +68,7 @@ public class JsonCredentialVersion extends CredentialVersion<JsonCredentialVersi
     return false;
   }
 
-  public JsonCredentialVersion setValue(Map<String, Object> value) {
+  public JsonCredentialVersion setValue(JsonNode value) {
     if (value == null) {
       throw new ParameterizedValidationException("error.missing_value");
     }

--- a/src/main/java/org/cloudfoundry/credhub/util/JsonObjectMapper.java
+++ b/src/main/java/org/cloudfoundry/credhub/util/JsonObjectMapper.java
@@ -2,6 +2,7 @@ package org.cloudfoundry.credhub.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import java.io.IOException;
 
@@ -37,5 +38,9 @@ public class JsonObjectMapper {
 
   public <T> T readValue(String stringValue, Class<T> type) throws IOException {
     return snakeCaseMapper.readValue(stringValue, type);
+  }
+
+  public JsonNode readTree(String stringValue) throws IOException {
+    return snakeCaseMapper.readTree(stringValue);
   }
 }

--- a/src/test/java/org/cloudfoundry/credhub/controller/v1/CredentialsControllerTypeSpecificSetTest.java
+++ b/src/test/java/org/cloudfoundry/credhub/controller/v1/CredentialsControllerTypeSpecificSetTest.java
@@ -2,6 +2,7 @@ package org.cloudfoundry.credhub.controller.v1;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import net.minidev.json.JSONObject;
 import org.cloudfoundry.credhub.CredentialManagerApp;
@@ -36,6 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.io.InputStream;
+import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -99,6 +101,7 @@ public class CredentialsControllerTypeSpecificSetTest {
           .put("username", USERNAME_VALUE)
           .put("password", PASSWORD_VALUE)
           .build());
+  private static final JsonNode jsonNode;
   @Rule
   public final SpringMethodRule springMethodRule = new SpringMethodRule();
   @Parameterized.Parameter
@@ -116,6 +119,16 @@ public class CredentialsControllerTypeSpecificSetTest {
   @Autowired
   private Encryptor encryptor;
   private MockMvc mockMvc;
+
+  static {
+    JsonNode tmp = null;
+    try {
+      tmp = new ObjectMapper().readTree(JSON_VALUE_JSON_STRING);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    jsonNode = tmp;
+  }
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object> parameters() {
@@ -237,13 +250,13 @@ public class CredentialsControllerTypeSpecificSetTest {
 
       void credentialAssertions(CredentialVersion credential) {
         JsonCredentialVersion jsonCredential = (JsonCredentialVersion) credential;
-        assertThat(jsonCredential.getValue(), equalTo(jsonValueMap));
+        assertThat(jsonCredential.getValue(), equalTo(jsonNode));
       }
 
       CredentialVersion createCredential(Encryptor encryptor) {
         return new JsonCredentialVersion(CREDENTIAL_NAME)
             .setEncryptor(encryptor)
-            .setValue(jsonValueMap)
+            .setValue(jsonNode)
             .setUuid(credentialUuid)
             .setVersionCreatedAt(FROZEN_TIME.minusSeconds(1));
       }

--- a/src/test/java/org/cloudfoundry/credhub/controller/v1/InterpolationControllerTest.java
+++ b/src/test/java/org/cloudfoundry/credhub/controller/v1/InterpolationControllerTest.java
@@ -1,6 +1,8 @@
 package org.cloudfoundry.credhub.controller.v1;
 
-import org.assertj.core.util.Maps;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.cloudfoundry.credhub.CredentialManagerApp;
 import org.cloudfoundry.credhub.data.CredentialVersionDataService;
 import org.cloudfoundry.credhub.domain.JsonCredentialVersion;
@@ -22,6 +24,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.UUID;
 
@@ -59,22 +62,36 @@ public class InterpolationControllerTest {
 
   @Test
   public void POST_replacesTheCredHubRefWithTheCredentialValue() throws Exception {
-    JsonCredentialVersion jsonCredential = mock(JsonCredentialVersion.class);
-    doReturn(Maps.newHashMap("secret1", "secret1-value")).when(jsonCredential).getValue();
-    when(jsonCredential.getName()).thenReturn("/cred1");
-    when(jsonCredential.getUuid()).thenReturn(UUID.randomUUID());
-
+    String credJson1 = "{\"secret1\":\"secret1-value\"}";
+    JsonNode jsonNode1;
+    try {
+        jsonNode1 = new ObjectMapper().readTree(credJson1);
+    } catch (IOException e) {
+        throw new RuntimeException(e);
+    }
     JsonCredentialVersion jsonCredential1 = mock(JsonCredentialVersion.class);
-    doReturn(Maps.newHashMap("secret2", "secret2-value")).when(jsonCredential1).getValue();
-    when(jsonCredential1.getName()).thenReturn("/cred2");
+    doReturn(jsonNode1).when(jsonCredential1).getValue();
+    when(jsonCredential1.getName()).thenReturn("/cred1");
     when(jsonCredential1.getUuid()).thenReturn(UUID.randomUUID());
 
-    doReturn(
-        Arrays.asList(jsonCredential)
-    ).when(mockCredentialVersionDataService).findNByName("/cred1", 1);
+    String credJson2 = "{\"secret2\":\"secret2-value\"}";
+    JsonNode jsonNode2;
+    try {
+        jsonNode2 = new ObjectMapper().readTree(credJson2);
+    } catch (IOException e) {
+        throw new RuntimeException(e);
+    }
+    JsonCredentialVersion jsonCredential2 = mock(JsonCredentialVersion.class);
+    doReturn(jsonNode2).when(jsonCredential2).getValue();
+    when(jsonCredential2.getName()).thenReturn("/cred2");
+    when(jsonCredential2.getUuid()).thenReturn(UUID.randomUUID());
 
     doReturn(
         Arrays.asList(jsonCredential1)
+    ).when(mockCredentialVersionDataService).findNByName("/cred1", 1);
+
+    doReturn(
+        Arrays.asList(jsonCredential2)
     ).when(mockCredentialVersionDataService).findNByName("/cred2", 1);
 
     mockMvc.perform(makeValidPostRequest()).andDo(print()).andExpect(status().isOk())

--- a/src/test/java/org/cloudfoundry/credhub/request/JsonSetRequestTest.java
+++ b/src/test/java/org/cloudfoundry/credhub/request/JsonSetRequestTest.java
@@ -1,12 +1,13 @@
 package org.cloudfoundry.credhub.request;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.cloudfoundry.credhub.credential.JsonCredentialValue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
 import java.util.Set;
 import javax.validation.ConstraintViolation;
 
@@ -34,12 +35,13 @@ public class JsonSetRequestTest {
 
   @Test
   public void whenAllFieldsAreSet_shouldBeValid() {
-    Map<String, Object> nested = new HashMap<>();
-    nested.put("key", 3);
-
-    Map<String, Object> value = new HashMap<>();
-    value.put("foo", "bar");
-    value.put("nested", nested);
+    String jsonString = "{\"foo\":\"bar\",\"nested\":{\"key\":3}}";
+    JsonNode value;
+    try {
+      value = new ObjectMapper().readTree(jsonString);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
 
     JsonSetRequest request = new JsonSetRequest();
     request.setName("some-name");


### PR DESCRIPTION
This PR allows CredHub to support any valid JSON, not just map. Requires a change to the CLI as well to read the values once set.

One part of the fix for cloudfoundry-incubator/credhub-cli#30