### PR TITLE
Fixes for docker-compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,8 @@ services:
     ports:
     - 9000:9000
     environment:
-      CREDHUB_AUTH_SERVER_EXTERNAL_URL: http://localhost:8080/uaa
-      CREDHUB_AUTH_SERVER_INTERNAL_URL: http://uaa:8080/uaa
+      CREDHUB_AUTH_SERVER_EXTERNAL_URL: http://localhost:8080/uaa/
+      CREDHUB_AUTH_SERVER_INTERNAL_URL: http://uaa:8080/uaa/
       #https://35.196.32.64:8443
       TRUST_STORE_PASSWORD: changeit
       LOG_LEVEL: debug

--- a/docker/config/security.yml
+++ b/docker/config/security.yml
@@ -3,7 +3,7 @@ security:
     acls:
       enabled: true
     permissions:
-      actors:
+    - actors:
         - "uaa-client:credhub_client"
       operations:
         - read


### PR DESCRIPTION
* In security bootstrapping, actors is an array.
* uaa requires a trailing / to correctly work (credhub CLI handles it ok with the slash, but the other library I was using didn't add the slash coming back from the /info endpoint and wasn't able to successfully login)