### PR TITLE
FIX Generate self signed certificate without the ca flag #134

### DIFF
--- a/components/credentials/src/main/java/org/cloudfoundry/credhub/generators/CertificateGenerator.java
+++ b/components/credentials/src/main/java/org/cloudfoundry/credhub/generators/CertificateGenerator.java
@@ -50,7 +50,11 @@ public class CertificateGenerator implements CredentialGenerator<CertificateCred
     if (params.isSelfSigned()) {
       try {
         final String cert = CertificateFormatter.pemOf(signedCertificateGenerator.getSelfSigned(keyPair, params));
-        return new CertificateCredentialValue(cert, cert, privatePem, null, params.isCa(), params.isSelfSigned(), true, false);
+        String ca = cert;
+        if (!params.isCa() && params.getCaName() == null ) {
+          ca = "";
+        }
+        return new CertificateCredentialValue(ca, cert, privatePem, null, params.isCa(), params.isSelfSigned(), true, false);
       } catch (final Exception e) {
         throw new RuntimeException(e);
       }

--- a/components/credentials/src/test/java/org/cloudfoundry/credhub/generators/CertificateGeneratorTest.java
+++ b/components/credentials/src/test/java/org/cloudfoundry/credhub/generators/CertificateGeneratorTest.java
@@ -264,7 +264,7 @@ public class CertificateGeneratorTest {
       equalTo(CertificateFormatter.pemOf(rootCaKeyPair.getPrivate())));
     assertThat(certificateCredential.getCertificate(),
       equalTo(CertificateFormatter.pemOf(certificate)));
-    assertThat(certificateCredential.getCa(), equalTo(CertificateFormatter.pemOf(certificate)));
+    assertThat(certificateCredential.getCa(), equalTo(""));
     verify(signedCertificateGenerator, times(1)).getSelfSigned(rootCaKeyPair, inputParameters);
   }
 


### PR DESCRIPTION
Hi all,

I just fixed the issue mentioned in #134 

So from my perspective it was not correct to export a Certificate as a CA when you didn't pass the `is_ca` flag or a valid (known) ca that should be used to sign the certificate.

So the fix was just looking into the arguments and only return a certificate in CA field if there a `known` ca or the `is_ca` flag was passed.

Hope you like that fix.

Kind regards