### PR TITLE
FIX accept CA Certificate without CA flag

### DIFF
--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/credential/CertificateCredentialValue.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/credential/CertificateCredentialValue.kt
@@ -23,9 +23,9 @@ import org.cloudfoundry.credhub.validators.ValidCertificateLength
 @MutuallyExclusive(message = ErrorMessages.MIXED_CA_NAME_AND_CA, fields = ["ca", "caName"])
 @ValidCertificateLength(message = ErrorMessages.INVALID_CERTIFICATE_LENGTH, fields = ["certificate", "ca"])
 @RequireValidCertificate(message = ErrorMessages.INVALID_CERTIFICATE_VALUE, fields = ["certificate"])
-@RequireCertificateSignedByCA(message = ErrorMessages.CERTIFICATE_WAS_NOT_SIGNED_BY_CA, fields = ["ca"])
+@RequireCertificateSignedByCA(message = ErrorMessages.CERTIFICATE_WAS_NOT_SIGNED_BY_CA, fields = ["certificate","ca"])
 @RequireCertificateMatchesPrivateKey(message = ErrorMessages.MISMATCHED_CERTIFICATE_AND_PRIVATE_KEY, fields = ["certificate", "privateKey"])
-@RequireValidCA(message = ErrorMessages.INVALID_CA_VALUE, fields = ["ca"])
+@RequireValidCA(message = ErrorMessages.INVALID_CA_VALUE, fields = ["certificate","ca"])
 class CertificateCredentialValue : CredentialValue {
 
     @JsonDeserialize(using = EmptyStringToNull::class)

--- a/components/credentials/src/test/java/org/cloudfoundry/credhub/requests/CertificateSetRequestTest.java
+++ b/components/credentials/src/test/java/org/cloudfoundry/credhub/requests/CertificateSetRequestTest.java
@@ -19,10 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.cloudfoundry.credhub.helpers.JsonTestHelper.deserialize;
 import static org.cloudfoundry.credhub.helpers.JsonTestHelper.deserializeAndValidate;
 import static org.cloudfoundry.credhub.helpers.JsonTestHelper.hasViolationWithMessage;
-import static org.cloudfoundry.credhub.utils.TestConstants.PRIVATE_KEY_4096;
-import static org.cloudfoundry.credhub.utils.TestConstants.TEST_CA;
-import static org.cloudfoundry.credhub.utils.TestConstants.TEST_CERTIFICATE;
-import static org.cloudfoundry.credhub.utils.TestConstants.TEST_PRIVATE_KEY;
+import static org.cloudfoundry.credhub.utils.TestConstants.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -389,6 +386,72 @@ public class CertificateSetRequestTest {
     );
 
     assertThat(violations, hasItem(hasViolationWithMessage(ErrorMessages.INVALID_CA_VALUE)));
+  }
+
+  @Test
+  public void whenCAValueIsNotACertificateAuthorityAndDifferentThanCertificate_isInvalid() {
+    final String setJson = JSONObject.toJSONString(
+            ImmutableMap.<String, String>builder()
+                    .put("ca", OTHER_TEST_CERTIFICATE)
+                    .put("certificate", TEST_CERTIFICATE)
+                    .put("private_key", TEST_PRIVATE_KEY)
+                    .build()
+    );
+
+    final String json = "{\n"
+            + "  \"name\": \"/example/certificate\",\n"
+            + "  \"type\": \"certificate\",\n"
+            + "  \"value\": " + setJson
+            + "}";
+    final Set<ConstraintViolation<CertificateSetRequest>> violations = deserializeAndValidate(
+            json,
+            CertificateSetRequest.class
+    );
+
+    assertThat(violations, hasItem(hasViolationWithMessage(ErrorMessages.INVALID_CA_VALUE)));
+  }
+
+  @Test
+  public void whenNoCaCertificateWasProvided_isValid() {
+    final String setJson = JSONObject.toJSONString(
+            ImmutableMap.<String, String>builder()
+                    .put("certificate", TEST_CERTIFICATE)
+                    .put("private_key", TEST_PRIVATE_KEY)
+                    .build()
+    );
+
+    final String json = "{\n"
+            + "  \"name\": \"/example/certificate\",\n"
+            + "  \"type\": \"certificate\",\n"
+            + "  \"value\": " + setJson
+            + "}";
+    final Set<ConstraintViolation<CertificateSetRequest>> violations = deserializeAndValidate(
+            json,
+            CertificateSetRequest.class
+    );
+
+    assertThat(violations.size(), equalTo(0));
+  }
+
+  @Test
+  public void whenNoCaAndNoCertificateWasProvided_isValid() {
+    final String setJson = JSONObject.toJSONString(
+            ImmutableMap.<String, String>builder()
+                    .put("private_key", TEST_PRIVATE_KEY)
+                    .build()
+    );
+
+    final String json = "{\n"
+            + "  \"name\": \"/example/certificate\",\n"
+            + "  \"type\": \"certificate\",\n"
+            + "  \"value\": " + setJson
+            + "}";
+    final Set<ConstraintViolation<CertificateSetRequest>> violations = deserializeAndValidate(
+            json,
+            CertificateSetRequest.class
+    );
+
+    assertThat(violations.size(), equalTo(0));
   }
 
   @Test

--- a/components/credentials/src/test/java/org/cloudfoundry/credhub/requests/CertificateSetRequestTest.java
+++ b/components/credentials/src/test/java/org/cloudfoundry/credhub/requests/CertificateSetRequestTest.java
@@ -366,7 +366,7 @@ public class CertificateSetRequestTest {
   }
 
   @Test
-  public void whenCAValueIsNotACertificateAuthority_isInvalid() {
+  public void whenCertificateWasNoSignedByTheCA_isInvalid() {
     final String setJson = JSONObject.toJSONString(
       ImmutableMap.<String, String>builder()
         .put("ca", TEST_CERTIFICATE)
@@ -385,7 +385,7 @@ public class CertificateSetRequestTest {
       CertificateSetRequest.class
     );
 
-    assertThat(violations, hasItem(hasViolationWithMessage(ErrorMessages.INVALID_CA_VALUE)));
+    assertThat(violations, hasItem(hasViolationWithMessage(ErrorMessages.CERTIFICATE_WAS_NOT_SIGNED_BY_CA)));
   }
 
   @Test


### PR DESCRIPTION
Hi @bruce-ricard

based on the comments of the PR: #139 and the Issue of: #134 the new PR  just implement / change the validation of the `CA` Certificate that we didn't break anything here.

Now there will be no error thrown if you try to import a `CA` Certificate that it not "valid" (doesn't contain the `CA:true` flag)
The import will be only accepted if the `CA` is the same as the `certificate` else the same logic as before will be used.

I also clean up the code a little bit and try that the `CAValidator` will look like `CertificateSignedByCAValidator`. 
I also added `CA` and the `CERTIFICATE` fields at the `Annotations` - `CertificateCredentialValue.kt` (Not required because we didn't use the `String[] fields` anymore but its more verbose that everyone can see what kind of fields will be used at the validator


Kind regards
Tobi 
