### PR TITLE
Add logic to generate certificates using minimum durations

### DIFF
--- a/applications/credhub-api/src/test/resources/application-minimum-duration.yml
+++ b/applications/credhub-api/src/test/resources/application-minimum-duration.yml
@@ -1,0 +1,3 @@
+certificates:
+  ca_minimum_duration: 1825
+  leaf_minimum_duration: 1460

--- a/applications/credhub-api/src/test/resources/application-minimum-duration.yml
+++ b/applications/credhub-api/src/test/resources/application-minimum-duration.yml
@@ -1,3 +1,4 @@
 certificates:
-  ca_minimum_duration: 1825
-  leaf_minimum_duration: 1460
+  ca_minimum_duration_in_days: 1825
+  leaf_minimum_duration_in_days: 1460
+

--- a/backends/credhub/src/docs/asciidoc/snippets/certificates-v1.adoc
+++ b/backends/credhub/src/docs/asciidoc/snippets/certificates-v1.adoc
@@ -11,7 +11,10 @@ See https://github.com/pivotal-cf/credhub-release/blob/master/docs/ca-rotation.m
 
 A minimum duration can be configured for leaf and CA certificates using the `certificates.leaf_minimum_duration_in_days` and `certificates.ca_minimum_duration_in_days` server-level configuration fields. When these fields are configured, if a request to generate or regenerate a certificate has a duration lower than the minimum, then the minimum duration is used instead.
 
-The API response will include a `duration_overridden` field that is `true` when the minimum duration was used instead, or `false` if the requested duration was used.
+The API response will include two fields:
+
+* A `duration_overridden` field that is `true` when the minimum duration was used instead, or `false` if the requested duration was used.
+* A `duration_used` field that is the duration (in days) used when the certificate was generated.
 
 ---
 
@@ -35,7 +38,7 @@ operation::POST__certificates_uuid_regenerate__returns_certificate[]
 Note:
 
 * If a certificate credential only has one version and it is marked as transitional the credential cannot be regenerated using this endpoint.
-* If the duration used to generate the currently active version of the certificate is lower than the minimum duration, the regenerated certificate will use the minimum duration instead and the response will contain the `duration_overridden` flag set to true.
+* If the duration used to generate the currently active version of the certificate is lower than the minimum duration, the regenerated certificate will use the minimum duration instead and the response will contain the `duration_overridden` flag set to true. The duration value used to regenerate the certificate is included in the `duration_used` field of the response.
 
 ---
 

--- a/backends/credhub/src/docs/asciidoc/snippets/certificates-v1.adoc
+++ b/backends/credhub/src/docs/asciidoc/snippets/certificates-v1.adoc
@@ -11,7 +11,7 @@ See https://github.com/pivotal-cf/credhub-release/blob/master/docs/ca-rotation.m
 
 A minimum duration can be configured for leaf and CA certificates using the `certificates.leaf_minimum_duration_in_days` and `certificates.ca_minimum_duration_in_days` server-level configuration fields. When these fields are configured, if a request to generate or regenerate a certificate has a duration lower than the minimum, then the minimum duration is used instead.
 
-When this feature is configured, the API response will include a `duration_overridden` field that is `true` when the minimum duration was used instead, or `false` if the requested duration was used. When the feature is not configured, this field is not present.
+The API response will include a `duration_overridden` field that is `true` when the minimum duration was used instead, or `false` if the requested duration was used.
 
 ---
 

--- a/backends/credhub/src/docs/asciidoc/snippets/certificates-v1.adoc
+++ b/backends/credhub/src/docs/asciidoc/snippets/certificates-v1.adoc
@@ -7,6 +7,14 @@ See https://github.com/pivotal-cf/credhub-release/blob/master/docs/ca-rotation.m
 
 ---
 
+=== Minimum Duration
+
+A minimum duration can be configured for leaf and CA certificates using the `certificates.leaf_minimum_duration_in_days` and `certificates.ca_minimum_duration_in_days` server-level configuration fields. When these fields are configured, if a request to generate or regenerate a certificate has a duration lower than the minimum, then the minimum duration is used instead.
+
+When this feature is configured, the API response will include a `duration_overridden` field that is `true` when the minimum duration was used instead, or `false` if the requested duration was used. When the feature is not configured, this field is not present.
+
+---
+
 === Get All Certificates
 operation::GET__certificates__returns_certificates[]
 
@@ -27,7 +35,7 @@ operation::POST__certificates_uuid_regenerate__returns_certificate[]
 Note:
 
 * If a certificate credential only has one version and it is marked as transitional the credential cannot be regenerated using this endpoint.
-* If the duration used to generate the currently active version of the certificate is lower than the minimum duration, the regenerated certificate will use the minimum duration instead and the response will contain the duration_overridden flag set to true.
+* If the duration used to generate the currently active version of the certificate is lower than the minimum duration, the regenerated certificate will use the minimum duration instead and the response will contain the `duration_overridden` flag set to true.
 
 ---
 

--- a/backends/credhub/src/docs/asciidoc/snippets/certificates-v1.adoc
+++ b/backends/credhub/src/docs/asciidoc/snippets/certificates-v1.adoc
@@ -24,7 +24,10 @@ Note: The certificate versions will be sorted in descending order of their creat
 === Regenerate a Certificate
 operation::POST__certificates_uuid_regenerate__returns_certificate[]
 
-Note: If a certificate credential only has one version and it is marked as transitional the credential cannot be regenerated using this endpoint.
+Note:
+
+* If a certificate credential only has one version and it is marked as transitional the credential cannot be regenerated using this endpoint.
+* If the duration used to generate the currently active version of the certificate is lower than the minimum duration, the regenerated certificate will use the minimum duration instead and the response will contain the duration_overridden flag set to true.
 
 ---
 

--- a/backends/credhub/src/docs/asciidoc/snippets/credentials-v1.adoc
+++ b/backends/credhub/src/docs/asciidoc/snippets/credentials-v1.adoc
@@ -80,7 +80,7 @@ operation::POST__generate_certificate_returns__certificate_credential[]
 
 Notes: 
 
-* If the duration is overridden by the minimum duration, the response will contain the `duration_overridden` flag set to true.
+* If the duration is overridden by the minimum duration, the response will contain the `duration_overridden` flag set to true. It will also include the actual duration used to generate the certificate in the `duration_used` field.
 * When the mode is set to converge, certificates are no longer regenerated if the duration doesn't match the existing certificate's duration.
 
 ---

--- a/backends/credhub/src/docs/asciidoc/snippets/credentials-v1.adoc
+++ b/backends/credhub/src/docs/asciidoc/snippets/credentials-v1.adoc
@@ -78,6 +78,8 @@ operation::GET__get_by_name__returns_results[]
 === Generate a Certificate Credential
 operation::POST__generate_certificate_returns__certificate_credential[]
 
+Note: If the duration is overridden by the minimum duration, the response will contain the duration_overridden flag set to true.
+
 ---
 
 === Generate a Password Credential

--- a/backends/credhub/src/docs/asciidoc/snippets/credentials-v1.adoc
+++ b/backends/credhub/src/docs/asciidoc/snippets/credentials-v1.adoc
@@ -78,7 +78,10 @@ operation::GET__get_by_name__returns_results[]
 === Generate a Certificate Credential
 operation::POST__generate_certificate_returns__certificate_credential[]
 
-Note: If the duration is overridden by the minimum duration, the response will contain the duration_overridden flag set to true.
+Notes: 
+
+* If the duration is overridden by the minimum duration, the response will contain the duration_overridden flag set to true.
+* When the mode is set to converge, certificates are no longer regenerated if the duration doesn't match the existing certificate's duration.
 
 ---
 

--- a/backends/credhub/src/docs/asciidoc/snippets/credentials-v1.adoc
+++ b/backends/credhub/src/docs/asciidoc/snippets/credentials-v1.adoc
@@ -80,7 +80,7 @@ operation::POST__generate_certificate_returns__certificate_credential[]
 
 Notes: 
 
-* If the duration is overridden by the minimum duration, the response will contain the duration_overridden flag set to true.
+* If the duration is overridden by the minimum duration, the response will contain the `duration_overridden` flag set to true.
 * When the mode is set to converge, certificates are no longer regenerated if the duration doesn't match the existing certificate's duration.
 
 ---

--- a/backends/credhub/src/docs/asciidoc/snippets/introduction.adoc
+++ b/backends/credhub/src/docs/asciidoc/snippets/introduction.adoc
@@ -36,3 +36,5 @@ Credential responses include a unique identifier in the key 'id'. This ID is a u
 As of 2.0.0, set requests always overwrite the credential that already exists.
 
 As of 2.0.1, generate requests can be set to overwrite, no-overwrite, or converge for the mode parameter. The default mode for generate is converge as of 2.0.0. Converge will only overwrite if the generate request parameters do not match the existing credential.
+
+As of 2.10.0, when the generate requests are set to converge for the mode parameter, converge will not overwrite certificates if duration is the only parameter that does not match the existing certificate credentials.

--- a/backends/credhub/src/main/kotlin/org/cloudfoundry/credhub/certificates/DefaultCertificatesHandler.kt
+++ b/backends/credhub/src/main/kotlin/org/cloudfoundry/credhub/certificates/DefaultCertificatesHandler.kt
@@ -25,6 +25,7 @@ import org.cloudfoundry.credhub.services.DefaultCertificateService
 import org.cloudfoundry.credhub.services.PermissionCheckingService
 import org.cloudfoundry.credhub.views.CertificateCredentialView
 import org.cloudfoundry.credhub.views.CertificateCredentialsView
+import org.cloudfoundry.credhub.views.CertificateGenerationView
 import org.cloudfoundry.credhub.views.CertificateVersionView
 import org.cloudfoundry.credhub.views.CertificateView
 import org.cloudfoundry.credhub.views.CredentialView
@@ -79,7 +80,7 @@ class DefaultCertificatesHandler(
 
         auditRecord.setVersion(credentialVersion)
 
-        return CertificateView(credentialVersion, concatenateCas)
+        return CertificateGenerationView(credentialVersion, concatenateCas)
     }
 
     override fun handleGetAllRequest(): CertificateCredentialsView {

--- a/backends/credhub/src/main/kotlin/org/cloudfoundry/credhub/credentials/DefaultCredentialsHandler.kt
+++ b/backends/credhub/src/main/kotlin/org/cloudfoundry/credhub/credentials/DefaultCredentialsHandler.kt
@@ -88,7 +88,7 @@ class DefaultCredentialsHandler(
         auditRecord.setVersion(credentialVersion)
         auditRecord.setResource(credentialVersion.credential)
 
-        return CredentialView.fromEntity(credentialVersion, concatenateCas)
+        return CredentialView.fromEntity(credentialVersion, concatenateCas, true)
     }
 
     override fun setCredential(setRequest: BaseCredentialSetRequest<*>): CredentialView {

--- a/backends/credhub/src/main/kotlin/org/cloudfoundry/credhub/regenerate/DefaultRegenerateHandler.kt
+++ b/backends/credhub/src/main/kotlin/org/cloudfoundry/credhub/regenerate/DefaultRegenerateHandler.kt
@@ -68,7 +68,7 @@ class DefaultRegenerateHandler(
         auditRecord.setVersion(credentialVersion)
         auditRecord.setResource(credentialVersion.credential)
 
-        return CredentialView.fromEntity(credentialVersion, concatenateCas)
+        return CredentialView.fromEntity(credentialVersion, concatenateCas, true)
     }
 
     override fun handleBulkRegenerate(signerName: String): BulkRegenerateResults {

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/handlers/DefaultRegenerateHandlerTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/handlers/DefaultRegenerateHandlerTest.java
@@ -185,7 +185,7 @@ public class DefaultRegenerateHandlerTest {
       .thenReturn(savedCredentialVersion);
 
     CredentialView actualCredentialView = subjectWithAclsEnabled.handleRegenerate(CREDENTIAL_NAME, null);
-    CredentialView expectedCredentialView = CredentialView.fromEntity(savedCredentialVersion);
+    CredentialView expectedCredentialView = CredentialView.fromEntity(savedCredentialVersion, false, true);
 
     verify(permissionCheckingService, times(1)).hasPermission(USER, CREDENTIAL_NAME, PermissionOperation.WRITE);
     assertThat(actualCredentialView).isEqualTo(expectedCredentialView);
@@ -291,7 +291,7 @@ public class DefaultRegenerateHandlerTest {
       .thenReturn(savedCredentialVersion);
 
     CredentialView actualCredentialView = subjectWithAclsDisabled.handleRegenerate(CREDENTIAL_NAME, null);
-    CredentialView expectedCredentialView = CredentialView.fromEntity(savedCredentialVersion);
+    CredentialView expectedCredentialView = CredentialView.fromEntity(savedCredentialVersion, false, true);
 
     verify(permissionCheckingService, times(0)).hasPermission(USER, CREDENTIAL_NAME, PermissionOperation.WRITE);
     assertThat(actualCredentialView).isEqualTo(expectedCredentialView);

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateGenerateTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateGenerateTest.java
@@ -128,6 +128,7 @@ public class CertificateGenerateTest {
         assertThat(result.getBoolean("certificate_authority"), equalTo(true));
         assertThat(result.getBoolean("self_signed"), equalTo(true));
         assertThat(result.getBoolean("generated"), equalTo(true));
+        assertThat(result.has("duration_overridden"), equalTo(false));
 
         assertThat(picardCert, notNullValue());
 

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateGenerateTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateGenerateTest.java
@@ -129,6 +129,7 @@ public class CertificateGenerateTest {
         assertThat(result.getBoolean("self_signed"), equalTo(true));
         assertThat(result.getBoolean("generated"), equalTo(true));
         assertThat(result.getBoolean("duration_overridden"), equalTo(false));
+        assertThat(result.getInt("duration_used"), equalTo(1));
 
         assertThat(picardCert, notNullValue());
 

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateGenerateTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateGenerateTest.java
@@ -128,7 +128,7 @@ public class CertificateGenerateTest {
         assertThat(result.getBoolean("certificate_authority"), equalTo(true));
         assertThat(result.getBoolean("self_signed"), equalTo(true));
         assertThat(result.getBoolean("generated"), equalTo(true));
-        assertThat(result.has("duration_overridden"), equalTo(false));
+        assertThat(result.getBoolean("duration_overridden"), equalTo(false));
 
         assertThat(picardCert, notNullValue());
 

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateMinimumDurationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateMinimumDurationTest.java
@@ -1,17 +1,10 @@
 package org.cloudfoundry.credhub.integration;
 
-import com.jayway.jsonpath.*;
-import org.cloudfoundry.credhub.CredhubTestApp;
-import org.cloudfoundry.credhub.domain.CertificateCredentialVersion;
-import org.cloudfoundry.credhub.entity.CertificateCredentialVersionData;
-import org.cloudfoundry.credhub.entity.Credential;
-import org.cloudfoundry.credhub.repositories.CredentialRepository;
-import org.cloudfoundry.credhub.repositories.CredentialVersionRepository;
-import org.cloudfoundry.credhub.util.CurrentTimeProvider;
-import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.function.Consumer;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -23,14 +16,26 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
-import java.util.function.Consumer;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import org.cloudfoundry.credhub.CredhubTestApp;
+import org.cloudfoundry.credhub.entity.CertificateCredentialVersionData;
+import org.cloudfoundry.credhub.entity.Credential;
+import org.cloudfoundry.credhub.repositories.CredentialRepository;
+import org.cloudfoundry.credhub.repositories.CredentialVersionRepository;
+import org.cloudfoundry.credhub.util.CurrentTimeProvider;
+import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static org.cloudfoundry.credhub.TestHelper.mockOutCurrentTimeProvider;
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
@@ -40,7 +45,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)
-@ActiveProfiles(profiles = { "unit-test", "minimum-duration" }, resolver = DatabaseProfileResolver.class)
+@ActiveProfiles(profiles = { "unit-test", "minimum-duration", }, resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
 public class CertificateMinimumDurationTest {

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateMinimumDurationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateMinimumDurationTest.java
@@ -100,6 +100,7 @@ public class CertificateMinimumDurationTest {
                 .getContentAsString());
 
         assertThat(generateResponse.read("$.duration_overridden").toString(), is("true"));
+        assertThat(generateResponse.read("$.duration_used"), is(1825));
         Instant expiryDate = Instant.parse(generateResponse.read("$.expiry_date").toString());
         assertThat(expiryDate, is(equalTo(mockCurrentTimeProvider.getInstant().plus(1825L, ChronoUnit.DAYS))));
     }
@@ -157,9 +158,11 @@ public class CertificateMinimumDurationTest {
         List<Object> versions = getVersionsForCertificate(CREDENTIAL_NAME);
 
         assertThat(generateResponse.read("$.duration_overridden"), is(true));
+        assertThat(generateResponse.read("$.duration_used"), is(1460));
         assertThat(regeneratedExpiryDate, is(equalTo(mockCurrentTimeProvider.getInstant().plus(1460L, ChronoUnit.DAYS))));
         assertThat(versions.size(), is(equalTo(2)));
         assertThat(regenerateResponse.read("$.duration_overridden"), is(false));
+        assertThat(regenerateResponse.read("$.duration_used"), is(1460));
     }
 
     @Test
@@ -195,6 +198,7 @@ public class CertificateMinimumDurationTest {
 
         assertThat(regeneratedExpiryDate, is(equalTo(mockCurrentTimeProvider.getInstant().plus(1460L, ChronoUnit.DAYS))));
         assertThat(regenerateResponse.read("$.duration_overridden"), is(equalTo(true)));
+        assertThat(regenerateResponse.read("$.duration_used"), is(equalTo(1460)));
         assertThat(versions.size(), is(equalTo(2)));
     }
 
@@ -223,6 +227,7 @@ public class CertificateMinimumDurationTest {
 
         assertThat(regeneratedExpiryDate, is(equalTo(mockCurrentTimeProvider.getInstant().plus(1460L, ChronoUnit.DAYS))));
         assertThat(regenerateResponse.read("$.duration_overridden"), is(equalTo(true)));
+        assertThat(regenerateResponse.read("$.duration_used"), is(equalTo(1460)));
         assertThat(versions.size(), is(equalTo(2)));
     }
 
@@ -249,6 +254,7 @@ public class CertificateMinimumDurationTest {
 
         assertThat(regeneratedExpiryDate, is(equalTo(mockCurrentTimeProvider.getInstant().plus(1460L, ChronoUnit.DAYS))));
         assertThat(regenerateResponse.read("$.duration_overridden"), is(equalTo(true)));
+        assertThat(regenerateResponse.read("$.duration_used"), is(equalTo(1460)));
         assertThat(versions.size(), is(equalTo(2)));
     }
 

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateMinimumDurationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateMinimumDurationTest.java
@@ -1,0 +1,163 @@
+package org.cloudfoundry.credhub.integration;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import org.cloudfoundry.credhub.CredhubTestApp;
+import org.cloudfoundry.credhub.util.CurrentTimeProvider;
+import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.cloudfoundry.credhub.TestHelper.mockOutCurrentTimeProvider;
+import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@ActiveProfiles(profiles = { "unit-test", "minimum-duration" }, resolver = DatabaseProfileResolver.class)
+@SpringBootTest(classes = CredhubTestApp.class)
+@Transactional
+public class CertificateMinimumDurationTest {
+    private static final String CREDENTIAL_NAME = "/credential/name";
+    private static final Instant FROZEN_TIME = Instant.ofEpochSecond(1400011001L);
+
+    @MockBean
+    private CurrentTimeProvider mockCurrentTimeProvider;
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Before
+    public void beforeEach() {
+        final Consumer<Long> fakeTimeSetter = mockOutCurrentTimeProvider(mockCurrentTimeProvider);
+
+        fakeTimeSetter.accept(FROZEN_TIME.toEpochMilli());
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .build();
+    }
+
+    @Test
+    public void generatingCA_usesTheMinimumDuration() throws Exception {
+        MockHttpServletRequestBuilder postRequest = post("/api/v1/data")
+                .header("Authorization", "Bearer " + ALL_PERMISSIONS_TOKEN)
+                .accept(APPLICATION_JSON)
+                .contentType(APPLICATION_JSON)
+                .content("{" +
+                        "\"type\":\"certificate\"," +
+                        "\"name\":\"" + CREDENTIAL_NAME + "\"," +
+                        "\"parameters\":{" +
+                        "\"common_name\":\"some-certificate\"," +
+                        "\"is_ca\":true," +
+                        "\"duration\":365" +
+                        "}" +
+                        "}");
+
+        mockMvc.perform(postRequest).andExpect(status().isOk())
+                .andDo(print())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        MockHttpServletRequestBuilder getRequest = get("/api/v1/certificates?name=" + CREDENTIAL_NAME)
+                .header("Authorization", "Bearer " + ALL_PERMISSIONS_TOKEN)
+                .accept(APPLICATION_JSON)
+                .contentType(APPLICATION_JSON);
+
+        DocumentContext response = JsonPath.parse(mockMvc.perform(getRequest).andExpect(status().isOk())
+                .andDo(print())
+                .andReturn()
+                .getResponse()
+                .getContentAsString());
+        Instant expiryDate = Instant.parse(response.read("$.certificates[0].versions[0].expiry_date").toString());
+        assertThat(expiryDate, is(equalTo(mockCurrentTimeProvider.getInstant().plus(1825L, ChronoUnit.DAYS))));
+    }
+
+    @Test
+    public void regeneratingALeafCertificate_usesTheMinimumDuration() throws Exception {
+        MockHttpServletRequestBuilder postRequest = post("/api/v1/data")
+                .header("Authorization", "Bearer " + ALL_PERMISSIONS_TOKEN)
+                .accept(APPLICATION_JSON)
+                .contentType(APPLICATION_JSON)
+                .content("{" +
+                        "\"type\":\"certificate\"," +
+                        "\"name\":\"" + CREDENTIAL_NAME + "\"," +
+                        "\"parameters\":{" +
+                        "\"common_name\":\"some-certificate\"," +
+                        "\"self_sign\":true," +
+                        "\"duration\":365" +
+                        "}" +
+                        "}");
+
+        mockMvc.perform(postRequest).andExpect(status().isOk())
+                .andDo(print())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        MockHttpServletRequestBuilder getRequest = get("/api/v1/certificates?name=" + CREDENTIAL_NAME)
+                .header("Authorization", "Bearer " + ALL_PERMISSIONS_TOKEN)
+                .accept(APPLICATION_JSON)
+                .contentType(APPLICATION_JSON);
+
+        DocumentContext response = JsonPath.parse(mockMvc.perform(getRequest).andExpect(status().isOk())
+                .andDo(print())
+                .andReturn()
+                .getResponse()
+                .getContentAsString());
+        String certificateId = response.read("$.certificates[0].id").toString();
+
+
+        postRequest = post("/api/v1/certificates/" + certificateId + "/regenerate")
+                .header("Authorization", "Bearer " + ALL_PERMISSIONS_TOKEN)
+                .accept(APPLICATION_JSON)
+                .contentType(APPLICATION_JSON);
+        mockMvc.perform(postRequest).andExpect(status().isOk())
+                .andDo(print())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        getRequest = get("/api/v1/certificates?name=" + CREDENTIAL_NAME)
+                .header("Authorization", "Bearer " + ALL_PERMISSIONS_TOKEN)
+                .accept(APPLICATION_JSON)
+                .contentType(APPLICATION_JSON);
+        response = JsonPath.parse(mockMvc.perform(getRequest).andExpect(status().isOk())
+                .andDo(print())
+                .andReturn()
+                .getResponse()
+                .getContentAsString());
+
+        Instant regeneratedExpiryDate = Instant.parse(response.read("$.certificates[0].versions[0].expiry_date").toString());
+        List<Object> versions = response.read("$.certificates[0].versions[*]");
+
+        assertThat(regeneratedExpiryDate, is(equalTo(mockCurrentTimeProvider.getInstant().plus(1460L, ChronoUnit.DAYS))));
+        assertThat(versions.size(), is(equalTo(2)));
+    }
+}

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateMinimumDurationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateMinimumDurationTest.java
@@ -156,10 +156,10 @@ public class CertificateMinimumDurationTest {
         Instant regeneratedExpiryDate = Instant.parse(regenerateResponse.read("$.expiry_date").toString());
         List<Object> versions = getVersionsForCertificate(CREDENTIAL_NAME);
 
-        assertThat(generateResponse.read("$.duration_overridden").toString(), is("true"));
+        assertThat(generateResponse.read("$.duration_overridden"), is(true));
         assertThat(regeneratedExpiryDate, is(equalTo(mockCurrentTimeProvider.getInstant().plus(1460L, ChronoUnit.DAYS))));
         assertThat(versions.size(), is(equalTo(2)));
-        assertThat(regenerateResponse.read("$.duration_overridden"), is(nullValue()));
+        assertThat(regenerateResponse.read("$.duration_overridden"), is(false));
     }
 
     @Test

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialFindTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialFindTest.java
@@ -378,6 +378,7 @@ public class CredentialFindTest {
             .content("{\n"
                     + "  \"name\" : \"sample-certificate\",\n"
                     + "  \"type\" : \"certificate\",\n"
+                    + "  \"mode\" : \"overwrite\",\n"
                     + "  \"parameters\" : {\n"
                     + "    \"common_name\" : \"some-common-name\",\n"
                     + "    \"is_ca\" : true,\n"

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/GenerateModeTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/GenerateModeTest.java
@@ -334,6 +334,55 @@ public class GenerateModeTest {
     }
 
     @Test
+    public void generatingACredential_whenConvergeIsSet_andTheCertificateParamsAreTheSameAsTheExistingCredentialExceptDuration_doesNotUpdatesTheCredential() throws Exception {
+        MockHttpServletRequestBuilder postRequest = post("/api/v1/data")
+                .header("Authorization", "Bearer " + ALL_PERMISSIONS_TOKEN)
+                .accept(APPLICATION_JSON)
+                .contentType(APPLICATION_JSON_UTF8)
+                .content("{" +
+                        "\"type\":\"certificate\"," +
+                        "\"name\":\"" + CREDENTIAL_NAME + "\"," +
+                        "\"parameters\":{" +
+                        "\"common_name\":\"some-certificate\"," +
+                        "\"is_ca\":true," +
+                        "\"duration\":365" +
+                        "}" +
+                        "}");
+
+        DocumentContext response = JsonPath.parse(mockMvc.perform(postRequest).andExpect(status().isOk())
+                .andDo(print())
+                .andReturn()
+                .getResponse()
+                .getContentAsString());
+
+        final String firstVersionId = response.read("$.id").toString();
+
+        postRequest = post("/api/v1/data")
+                .header("Authorization", "Bearer " + ALL_PERMISSIONS_TOKEN)
+                .accept(APPLICATION_JSON)
+                .contentType(APPLICATION_JSON_UTF8)
+                .content("{" +
+                        "\"type\":\"certificate\"," +
+                        "\"name\":\"" + CREDENTIAL_NAME + "\"," +
+                        "\"parameters\":{" +
+                        "\"common_name\":\"some-certificate\"," +
+                        "\"is_ca\":true," +
+                        "\"duration\":730" +
+                        "}" +
+                        "}");
+
+        response = JsonPath.parse(mockMvc.perform(postRequest).andExpect(status().isOk())
+                .andDo(print())
+                .andReturn()
+                .getResponse()
+                .getContentAsString());
+
+        final String secondVersionId = response.read("$.id").toString();
+
+        assertThat(secondVersionId, is(equalTo(firstVersionId)));
+    }
+
+    @Test
     public void generatingACredential_whenModeIsSetAsParameter_returnsA400() throws Exception {
         final MockHttpServletRequestBuilder postRequest = post("/api/v1/data")
                 .header("Authorization", "Bearer " + ALL_PERMISSIONS_TOKEN)

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/certificates/CertificatesControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/certificates/CertificatesControllerTest.kt
@@ -112,6 +112,7 @@ class CertificatesControllerTest {
             """.trimIndent()
         certificateView = CertificateGenerationView(certificateCredentialVersion, false)
         (certificateView as CertificateGenerationView).durationOverridden = true
+        (certificateView as CertificateGenerationView).durationUsed = 1234
         spyCertificatesHandler.handleRegenerate__returns_credentialView = certificateView
 
         val mvcResult = mockMvc
@@ -167,6 +168,7 @@ class CertificatesControllerTest {
               "certificate_authority": false,
               "self_signed": false,
               "duration_overridden": true,
+              "duration_used": 1234,
               "value": {
                 "ca": "${TestConstants.TEST_CA}",
                 "certificate": "${TestConstants.TEST_CERTIFICATE}",

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/certificates/CertificatesControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/certificates/CertificatesControllerTest.kt
@@ -117,7 +117,7 @@ class CertificatesControllerTest {
             .perform(
                 post("${CertificatesController.ENDPOINT}/{certificateId}/regenerate", certificateId.toString())
                     .credHubAuthHeader()
-                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .accept(MediaType.APPLICATION_JSON)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(requestBody)
             ).andExpect(status().isOk)
@@ -209,7 +209,7 @@ class CertificatesControllerTest {
             .perform(
                 get(CertificatesController.ENDPOINT)
                     .credHubAuthHeader()
-                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .accept(MediaType.APPLICATION_JSON)
             ).andExpect(status().isOk)
             .andDo(
                 document(
@@ -278,7 +278,7 @@ class CertificatesControllerTest {
             .perform(
                 get(CertificatesController.ENDPOINT)
                     .credHubAuthHeader()
-                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .accept(MediaType.APPLICATION_JSON)
             ).andExpect(status().isOk)
             .andReturn()
 
@@ -334,7 +334,7 @@ class CertificatesControllerTest {
             .perform(
                 get(CertificatesController.ENDPOINT)
                     .credHubAuthHeader()
-                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .accept(MediaType.APPLICATION_JSON)
             ).andExpect(status().isOk)
             .andReturn()
 
@@ -391,7 +391,7 @@ class CertificatesControllerTest {
             .perform(
                 get(CertificatesController.ENDPOINT)
                     .credHubAuthHeader()
-                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .accept(MediaType.APPLICATION_JSON)
                     .param("name", name)
             ).andExpect(status().isOk)
             .andDo(
@@ -455,7 +455,7 @@ class CertificatesControllerTest {
             .perform(
                 get(CertificatesController.ENDPOINT)
                     .credHubAuthHeader()
-                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .accept(MediaType.APPLICATION_JSON)
                     .param("name", name)
             ).andExpect(status().isOk).andReturn()
 
@@ -503,7 +503,7 @@ class CertificatesControllerTest {
             .perform(
                 put("${CertificatesController.ENDPOINT}/{certificateId}/update_transitional_version", certificateId.toString())
                     .credHubAuthHeader()
-                    .accept(MediaType.APPLICATION_JSON_UTF8)
+                    .accept(MediaType.APPLICATION_JSON)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(requestBody)
             ).andExpect(status().isOk)
@@ -536,7 +536,7 @@ class CertificatesControllerTest {
         val mvcResult = mockMvc.perform(
             get("${CertificatesController.ENDPOINT}/{certificateId}/versions", certificateId.toString())
                 .credHubAuthHeader()
-                .accept(MediaType.APPLICATION_JSON_UTF8)
+                .accept(MediaType.APPLICATION_JSON)
                 .param("current", "true")
         ).andExpect(status().isOk)
             .andDo(
@@ -607,7 +607,7 @@ class CertificatesControllerTest {
         val mvcResult = mockMvc.perform(
             get("${CertificatesController.ENDPOINT}/{certificateId}/versions", certificateId.toString())
                 .credHubAuthHeader()
-                .accept(MediaType.APPLICATION_JSON_UTF8)
+                .accept(MediaType.APPLICATION_JSON)
                 .param("current", "true")
         ).andExpect(status().isOk).andReturn()
 
@@ -678,7 +678,8 @@ class CertificatesControllerTest {
             post("${CertificatesController.ENDPOINT}/{certificateId}/versions", certificateId.toString())
                 .credHubAuthHeader()
                 .accept(MediaType.APPLICATION_JSON)
-                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                .characterEncoding("utf-8")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody)
         ).andExpect(status().isOk)
             .andDo(
@@ -727,7 +728,7 @@ class CertificatesControllerTest {
         val mvcResult = mockMvc.perform(
             delete("${CertificatesController.ENDPOINT}/{certificateId}/versions/{versionId}", certificateId.toString(), versionId.toString())
                 .credHubAuthHeader()
-                .accept(MediaType.APPLICATION_JSON_UTF8)
+                .accept(MediaType.APPLICATION_JSON)
         ).andExpect(status().isOk)
             .andDo(
                 document(

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/certificates/CertificatesControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/certificates/CertificatesControllerTest.kt
@@ -18,6 +18,7 @@ import org.cloudfoundry.credhub.requests.UpdateTransitionalVersionRequest
 import org.cloudfoundry.credhub.utils.TestConstants
 import org.cloudfoundry.credhub.views.CertificateCredentialView
 import org.cloudfoundry.credhub.views.CertificateCredentialsView
+import org.cloudfoundry.credhub.views.CertificateGenerationView
 import org.cloudfoundry.credhub.views.CertificateVersionView
 import org.cloudfoundry.credhub.views.CertificateView
 import org.junit.Before
@@ -109,8 +110,8 @@ class CertificatesControllerTest {
             """
             {"set_as_transitional": true, "allow_transitional_parent_to_sign": true, "metadata": {"description": "example metadata"}}
             """.trimIndent()
-
-        certificateView.durationOverridden = true
+        certificateView = CertificateGenerationView(certificateCredentialVersion, false)
+        (certificateView as CertificateGenerationView).durationOverridden = true
         spyCertificatesHandler.handleRegenerate__returns_credentialView = certificateView
 
         val mvcResult = mockMvc

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerGenerateTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerGenerateTest.kt
@@ -25,6 +25,7 @@ import org.cloudfoundry.credhub.requests.CertificateGenerationRequestParameters
 import org.cloudfoundry.credhub.requests.CredentialRegenerateRequest
 import org.cloudfoundry.credhub.requests.RsaSshGenerationParameters
 import org.cloudfoundry.credhub.utils.TestConstants
+import org.cloudfoundry.credhub.views.CertificateGenerationView
 import org.cloudfoundry.credhub.views.CertificateView
 import org.cloudfoundry.credhub.views.CredentialView
 import org.junit.Before
@@ -282,7 +283,7 @@ class CredentialsControllerGenerateTest {
         certificateCredentialVersion.uuid = uuid
         certificateCredentialVersion.metadata = metadata
 
-        spyCredentialsHandler.generateCredential__returns_credentialView = CertificateView(
+        spyCredentialsHandler.generateCredential__returns_credentialView = CertificateGenerationView(
             certificateCredentialVersion,
             true
         )

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerGenerateTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerGenerateTest.kt
@@ -274,17 +274,17 @@ class CredentialsControllerGenerateTest {
         Mockito.doReturn(TestConstants.TEST_PRIVATE_KEY).`when`<Encryptor>(encryptor).decrypt(ArgumentMatchers.any())
 
         val certificateCredentialVersion = CertificateCredentialVersion(
-                certificateCredentialValue,
-                "/some-certificate-name",
-                encryptor
+            certificateCredentialValue,
+            "/some-certificate-name",
+            encryptor
         )
         certificateCredentialVersion.versionCreatedAt = Instant.ofEpochSecond(1549053472L)
         certificateCredentialVersion.uuid = uuid
         certificateCredentialVersion.metadata = metadata
 
         spyCredentialsHandler.generateCredential__returns_credentialView = CertificateView(
-                certificateCredentialVersion,
-                true
+            certificateCredentialVersion,
+            true
         )
 
         // language=json

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerGenerateTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerGenerateTest.kt
@@ -268,7 +268,8 @@ class CredentialsControllerGenerateTest {
             false,
             true,
             false,
-            true
+            true,
+            1460
         )
 
         val encryptor = Mockito.mock(Encryptor::class.java)
@@ -385,7 +386,6 @@ class CredentialsControllerGenerateTest {
 
         val actualResponseBody = mvcResult.response.contentAsString
 
-        print(actualResponseBody)
         // language=json
         val expectedResponseBody =
             """
@@ -401,6 +401,7 @@ class CredentialsControllerGenerateTest {
                   "self_signed": false,
                   "generated": true,
                   "duration_overridden": true,
+                  "duration_used": 1460,
                   "value": {
                     "ca": "${TestConstants.TEST_CA}",
                     "certificate": "${TestConstants.TEST_CERTIFICATE}",

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsPostIntegrationTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsPostIntegrationTest.kt
@@ -74,7 +74,7 @@ class CredentialsPostIntegrationTest {
             true,
             true,
             true,
-            null
+            false
         )
 
         Mockito.doReturn(caCredentialValue).`when`<CertificateAuthorityService>(certificateAuthorityService).findActiveVersion("/myCA")

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsPostIntegrationTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsPostIntegrationTest.kt
@@ -73,7 +73,8 @@ class CredentialsPostIntegrationTest {
             true,
             true,
             true,
-            true
+            true,
+            null
         )
 
         Mockito.doReturn(caCredentialValue).`when`<CertificateAuthorityService>(certificateAuthorityService).findActiveVersion("/myCA")

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsPostIntegrationTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsPostIntegrationTest.kt
@@ -74,7 +74,8 @@ class CredentialsPostIntegrationTest {
             true,
             true,
             true,
-            false
+            false,
+            730
         )
 
         Mockito.doReturn(caCredentialValue).`when`<CertificateAuthorityService>(certificateAuthorityService).findActiveVersion("/myCA")

--- a/components/credentials/src/main/java/org/cloudfoundry/credhub/generators/CertificateGenerator.java
+++ b/components/credentials/src/main/java/org/cloudfoundry/credhub/generators/CertificateGenerator.java
@@ -56,12 +56,10 @@ public class CertificateGenerator implements CredentialGenerator<CertificateCred
     }
 
     final int originalDuration = params.getDuration();
-    Boolean durationOverridden = null;
 
-    if (isMinimumDurationEnabled()) {
-      params.setDuration(getCertificateDuration(params));
-      durationOverridden = (originalDuration != params.getDuration());
-    }
+    params.setDuration(getCertificateDuration(params));
+
+    boolean durationOverridden = (originalDuration != params.getDuration());
 
     if (params.isSelfSigned()) {
       try {
@@ -134,9 +132,5 @@ public class CertificateGenerator implements CredentialGenerator<CertificateCred
       return Math.max(params.getDuration(), caMinimumDurationInDays);
     }
     return Math.max(params.getDuration(), leafMinimumDurationInDays);
-  }
-
-  private boolean isMinimumDurationEnabled() {
-    return (caMinimumDurationInDays !=0 || leafMinimumDurationInDays != 0);
   }
 }

--- a/components/credentials/src/main/java/org/cloudfoundry/credhub/generators/CertificateGenerator.java
+++ b/components/credentials/src/main/java/org/cloudfoundry/credhub/generators/CertificateGenerator.java
@@ -58,10 +58,9 @@ public class CertificateGenerator implements CredentialGenerator<CertificateCred
     final int originalDuration = params.getDuration();
     Boolean durationOverridden = null;
 
-    params.setDuration(getCertificateDuration(params));
-
-    if (originalDuration != params.getDuration()) {
-      durationOverridden = true;
+    if (isMinimumDurationEnabled()) {
+      params.setDuration(getCertificateDuration(params));
+      durationOverridden = (originalDuration != params.getDuration());
     }
 
     if (params.isSelfSigned()) {
@@ -135,5 +134,9 @@ public class CertificateGenerator implements CredentialGenerator<CertificateCred
       return Math.max(params.getDuration(), caMinimumDurationInDays);
     }
     return Math.max(params.getDuration(), leafMinimumDurationInDays);
+  }
+
+  private boolean isMinimumDurationEnabled() {
+    return (caMinimumDurationInDays !=0 || leafMinimumDurationInDays != 0);
   }
 }

--- a/components/credentials/src/main/java/org/cloudfoundry/credhub/generators/CertificateGenerator.java
+++ b/components/credentials/src/main/java/org/cloudfoundry/credhub/generators/CertificateGenerator.java
@@ -64,7 +64,7 @@ public class CertificateGenerator implements CredentialGenerator<CertificateCred
     if (params.isSelfSigned()) {
       try {
         final String cert = CertificateFormatter.pemOf(signedCertificateGenerator.getSelfSigned(keyPair, params));
-        return new CertificateCredentialValue(cert, cert, privatePem, null, null, params.isCa(), params.isSelfSigned(), true, false, durationOverridden);
+        return new CertificateCredentialValue(cert, cert, privatePem, null, null, params.isCa(), params.isSelfSigned(), true, false, durationOverridden, params.getDuration());
       } catch (final Exception e) {
         throw new RuntimeException(e);
       }
@@ -102,7 +102,7 @@ public class CertificateGenerator implements CredentialGenerator<CertificateCred
           certificateReader.getCertificate(),
           PrivateKeyReader.getPrivateKey(signingCaPrivateKey)
         );
-        return new CertificateCredentialValue(signingCaCertificate, CertificateFormatter.pemOf(cert), privatePem, caName, trustedCaCertificate, params.isCa(), params.isSelfSigned(), true, false, durationOverridden);
+        return new CertificateCredentialValue(signingCaCertificate, CertificateFormatter.pemOf(cert), privatePem, caName, trustedCaCertificate, params.isCa(), params.isSelfSigned(), true, false, durationOverridden, params.getDuration());
       } catch (final Exception e) {
         throw new RuntimeException(e);
       }

--- a/components/credentials/src/main/java/org/cloudfoundry/credhub/generators/CertificateGenerator.java
+++ b/components/credentials/src/main/java/org/cloudfoundry/credhub/generators/CertificateGenerator.java
@@ -55,8 +55,10 @@ public class CertificateGenerator implements CredentialGenerator<CertificateCred
       throw new RuntimeException(e);
     }
 
-    if(this.caMinimumDuration != null) {
-      params.setDuration(Math.max(params.getDuration(), this.caMinimumDuration));
+    if (params.isCa() && caMinimumDuration != null) {
+      params.setDuration(Math.max(params.getDuration(), caMinimumDuration));
+    } else if (!params.isCa() && leafMinimumDuration != null) {
+      params.setDuration(Math.max(params.getDuration(), leafMinimumDuration));
     }
 
     if (params.isSelfSigned()) {

--- a/components/credentials/src/main/java/org/cloudfoundry/credhub/generators/CertificateGenerator.java
+++ b/components/credentials/src/main/java/org/cloudfoundry/credhub/generators/CertificateGenerator.java
@@ -23,8 +23,6 @@ import org.cloudfoundry.credhub.utils.PrivateKeyReader;
 @Component
 public class CertificateGenerator implements CredentialGenerator<CertificateCredentialValue> {
 
-  private static final Logger LOGGER = LogManager.getLogger(CertificateGenerator.class.getName());
-
   private final RsaKeyPairGenerator keyGenerator;
   private final SignedCertificateGenerator signedCertificateGenerator;
   private final CertificateAuthorityService certificateAuthorityService;
@@ -69,7 +67,6 @@ public class CertificateGenerator implements CredentialGenerator<CertificateCred
 
     if (originalDuration != params.getDuration()) {
       durationOverridden = true;
-      LOGGER.info("Certificate duration overridden, original duration: {} - duration used: {}", originalDuration, params.getDuration());
     }
 
     if (params.isSelfSigned()) {

--- a/components/credentials/src/main/java/org/cloudfoundry/credhub/generators/CertificateGenerator.java
+++ b/components/credentials/src/main/java/org/cloudfoundry/credhub/generators/CertificateGenerator.java
@@ -24,8 +24,8 @@ public class CertificateGenerator implements CredentialGenerator<CertificateCred
   private final RsaKeyPairGenerator keyGenerator;
   private final SignedCertificateGenerator signedCertificateGenerator;
   private final CertificateAuthorityService certificateAuthorityService;
-  private final Integer caMinimumDuration;
-  private final Integer leafMinimumDuration;
+  private final int caMinimumDurationInDays;
+  private final int leafMinimumDurationInDays;
 
 
   @Autowired
@@ -33,14 +33,14 @@ public class CertificateGenerator implements CredentialGenerator<CertificateCred
     final RsaKeyPairGenerator keyGenerator,
     final SignedCertificateGenerator signedCertificateGenerator,
     final CertificateAuthorityService certificateAuthorityService,
-    @Value("${certificates.ca_minimum_duration:#{null}}") final Integer caMinimumDuration,
-    @Value("${certificates.leaf_minimum_duration:#{null}}") final Integer leafMinimumDuration) {
+    @Value("${certificates.ca_minimum_duration_in_days:#{0}}") final int caMinimumDurationInDays,
+    @Value("${certificates.leaf_minimum_duration_in_days:#{0}}") final int leafMinimumDurationInDays) {
     super();
     this.keyGenerator = keyGenerator;
     this.signedCertificateGenerator = signedCertificateGenerator;
     this.certificateAuthorityService = certificateAuthorityService;
-    this.caMinimumDuration = caMinimumDuration;
-    this.leafMinimumDuration = leafMinimumDuration;
+    this.caMinimumDurationInDays = caMinimumDurationInDays;
+    this.leafMinimumDurationInDays = leafMinimumDurationInDays;
   }
 
   @Override
@@ -131,11 +131,9 @@ public class CertificateGenerator implements CredentialGenerator<CertificateCred
   }
 
   private int getCertificateDuration(final CertificateGenerationParameters params) {
-    if (params.isCa() && caMinimumDuration != null) {
-      return Math.max(params.getDuration(), caMinimumDuration);
-    } else if (!params.isCa() && leafMinimumDuration != null) {
-      return Math.max(params.getDuration(), leafMinimumDuration);
+    if (params.isCa()) {
+      return Math.max(params.getDuration(), caMinimumDurationInDays);
     }
-    return params.getDuration();
+    return Math.max(params.getDuration(), leafMinimumDurationInDays);
   }
 }

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/credential/CertificateCredentialValue.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/credential/CertificateCredentialValue.kt
@@ -58,6 +58,9 @@ class CertificateCredentialValue : CredentialValue {
     @JsonIgnore
     var durationOverridden: Boolean = false
 
+    @JsonIgnore
+    var durationUsed: Int = 0
+
     constructor() : super() {}
 
     constructor(
@@ -70,7 +73,8 @@ class CertificateCredentialValue : CredentialValue {
         selfSigned: Boolean,
         generated: Boolean?,
         transitional: Boolean,
-        durationOverridden: Boolean
+        durationOverridden: Boolean,
+        durationUsed: Int
     ) : super() {
         this.ca = ca
         this.trustedCa = trustedCa
@@ -82,6 +86,7 @@ class CertificateCredentialValue : CredentialValue {
         this.generated = generated
         this.caName = caName
         this.durationOverridden = durationOverridden
+        this.durationUsed = durationUsed
     }
 
     constructor(
@@ -103,7 +108,8 @@ class CertificateCredentialValue : CredentialValue {
         selfSigned,
         generated,
         transitional,
-        false
+        false,
+        0
     ) {
     }
 
@@ -126,7 +132,8 @@ class CertificateCredentialValue : CredentialValue {
         selfSigned,
         generated,
         transitional,
-        false
+        false,
+        0
     ) {
         this.versionCreatedAt = versionCreatedAt
     }

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/credential/CertificateCredentialValue.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/credential/CertificateCredentialValue.kt
@@ -55,6 +55,9 @@ class CertificateCredentialValue : CredentialValue {
     @JsonIgnore
     var versionCreatedAt: Instant? = null
 
+    @JsonInclude(Include.NON_NULL)
+    var durationOverridden: Boolean? = null
+
     constructor() : super() {}
 
     constructor(
@@ -66,7 +69,8 @@ class CertificateCredentialValue : CredentialValue {
         certificateAuthority: Boolean,
         selfSigned: Boolean,
         generated: Boolean?,
-        transitional: Boolean
+        transitional: Boolean,
+        durationOverridden: Boolean?
     ) : super() {
         this.ca = ca
         this.trustedCa = trustedCa
@@ -77,6 +81,7 @@ class CertificateCredentialValue : CredentialValue {
         this.selfSigned = selfSigned
         this.generated = generated
         this.caName = caName
+        this.durationOverridden = durationOverridden
     }
 
     constructor(
@@ -97,7 +102,8 @@ class CertificateCredentialValue : CredentialValue {
         certificateAuthority,
         selfSigned,
         generated,
-        transitional
+        transitional,
+        null
     ) {
     }
 
@@ -119,7 +125,8 @@ class CertificateCredentialValue : CredentialValue {
         certificateAuthority,
         selfSigned,
         generated,
-        transitional
+        transitional,
+        null
     ) {
         this.versionCreatedAt = versionCreatedAt
     }

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/credential/CertificateCredentialValue.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/credential/CertificateCredentialValue.kt
@@ -55,8 +55,8 @@ class CertificateCredentialValue : CredentialValue {
     @JsonIgnore
     var versionCreatedAt: Instant? = null
 
-    @JsonInclude(Include.NON_NULL)
-    var durationOverridden: Boolean? = null
+    @JsonIgnore
+    var durationOverridden: Boolean = false
 
     constructor() : super() {}
 
@@ -70,7 +70,7 @@ class CertificateCredentialValue : CredentialValue {
         selfSigned: Boolean,
         generated: Boolean?,
         transitional: Boolean,
-        durationOverridden: Boolean?
+        durationOverridden: Boolean
     ) : super() {
         this.ca = ca
         this.trustedCa = trustedCa
@@ -103,7 +103,7 @@ class CertificateCredentialValue : CredentialValue {
         selfSigned,
         generated,
         transitional,
-        null
+        false
     ) {
     }
 
@@ -126,7 +126,7 @@ class CertificateCredentialValue : CredentialValue {
         selfSigned,
         generated,
         transitional,
-        null
+        false
     ) {
         this.versionCreatedAt = versionCreatedAt
     }

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/domain/CertificateCredentialVersion.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/domain/CertificateCredentialVersion.kt
@@ -12,7 +12,7 @@ class CertificateCredentialVersion(delegate: CertificateCredentialVersionData) :
     lateinit var parsedCertificate: CertificateReader
         private set
 
-    var durationOverridden: Boolean? = null
+    var durationOverridden: Boolean = false
 
     var ca: String?
         get() = (delegate as CertificateCredentialVersionData).ca

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/domain/CertificateCredentialVersion.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/domain/CertificateCredentialVersion.kt
@@ -4,7 +4,6 @@ import org.apache.commons.lang3.StringUtils
 import org.cloudfoundry.credhub.credential.CertificateCredentialValue
 import org.cloudfoundry.credhub.entity.CertificateCredentialVersionData
 import org.cloudfoundry.credhub.requests.GenerationParameters
-import org.cloudfoundry.credhub.services.CredentialVersionDataService
 import org.cloudfoundry.credhub.utils.CertificateReader
 import java.time.Instant
 import java.util.Objects

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/domain/CertificateCredentialVersion.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/domain/CertificateCredentialVersion.kt
@@ -13,6 +13,7 @@ class CertificateCredentialVersion(delegate: CertificateCredentialVersionData) :
         private set
 
     var durationOverridden: Boolean = false
+    var durationUsed: Int = 0
 
     var ca: String?
         get() = (delegate as CertificateCredentialVersionData).ca
@@ -95,6 +96,7 @@ class CertificateCredentialVersion(delegate: CertificateCredentialVersionData) :
         this.isSelfSigned = certificate.selfSigned
         this.generated = certificate.generated
         this.durationOverridden = certificate.durationOverridden
+        this.durationUsed = certificate.durationUsed
     }
 
     override fun getCredentialType(): String {

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/domain/CertificateCredentialVersion.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/domain/CertificateCredentialVersion.kt
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.StringUtils
 import org.cloudfoundry.credhub.credential.CertificateCredentialValue
 import org.cloudfoundry.credhub.entity.CertificateCredentialVersionData
 import org.cloudfoundry.credhub.requests.GenerationParameters
+import org.cloudfoundry.credhub.services.CredentialVersionDataService
 import org.cloudfoundry.credhub.utils.CertificateReader
 import java.time.Instant
 import java.util.Objects
@@ -11,6 +12,8 @@ import java.util.Objects
 class CertificateCredentialVersion(delegate: CertificateCredentialVersionData) : CredentialVersion(delegate) {
     lateinit var parsedCertificate: CertificateReader
         private set
+
+    var durationOverridden: Boolean? = null
 
     var ca: String?
         get() = (delegate as CertificateCredentialVersionData).ca
@@ -92,6 +95,7 @@ class CertificateCredentialVersion(delegate: CertificateCredentialVersionData) :
         this.trustedCa = certificate.trustedCa
         this.isSelfSigned = certificate.selfSigned
         this.generated = certificate.generated
+        this.durationOverridden = certificate.durationOverridden
     }
 
     override fun getCredentialType(): String {

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/domain/CertificateCredentialVersion.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/domain/CertificateCredentialVersion.kt
@@ -110,7 +110,7 @@ class CertificateCredentialVersion(delegate: CertificateCredentialVersionData) :
 
         val parameters = generationParameters as CertificateGenerationParameters?
         val existingGenerationParameters = CertificateGenerationParameters(parsedCertificate, caName)
-        return existingGenerationParameters == parameters
+        return existingGenerationParameters.equalsIgnoringDuration(parameters)
     }
 
     fun setTransitional(transitional: Boolean) {

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/domain/CertificateGenerationParameters.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/domain/CertificateGenerationParameters.kt
@@ -38,7 +38,7 @@ import javax.security.auth.x500.X500Principal
 class CertificateGenerationParameters : GenerationParameters {
 
     val keyLength: Int
-    val duration: Int
+    var duration: Int
     val isSelfSigned: Boolean
     val caName: String?
     val isCa: Boolean

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/domain/CertificateGenerationParameters.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/domain/CertificateGenerationParameters.kt
@@ -90,15 +90,8 @@ class CertificateGenerationParameters : GenerationParameters {
         }
 
         val that = other as CertificateGenerationParameters?
-        return keyLength == that!!.keyLength &&
-            duration == that.duration &&
-            isSelfSigned == that.isSelfSigned &&
-            isCa == that.isCa &&
-            (caName == that.caName || caName == null || that.caName == null) &&
-            X500Name(that.x500Principal!!.name) == X500Name(this.x500Principal!!.name) &&
-            alternativeNames == that.alternativeNames &&
-            extendedKeyUsage == that.extendedKeyUsage &&
-            keyUsage == that.keyUsage
+        return duration == that!!.duration &&
+            equalsIgnoringDuration(that);
     }
 
     fun equalsIgnoringDuration(other: CertificateGenerationParameters?): Boolean {

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/domain/CertificateGenerationParameters.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/domain/CertificateGenerationParameters.kt
@@ -101,6 +101,17 @@ class CertificateGenerationParameters : GenerationParameters {
             keyUsage == that.keyUsage
     }
 
+    fun equalsIgnoringDuration(other: CertificateGenerationParameters?): Boolean {
+        return keyLength == other!!.keyLength &&
+            isSelfSigned == other.isSelfSigned &&
+            isCa == other.isCa &&
+            (caName == other.caName || caName == null || other.caName == null) &&
+            X500Name(other.x500Principal!!.name) == X500Name(this.x500Principal!!.name) &&
+            alternativeNames == other.alternativeNames &&
+            extendedKeyUsage == other.extendedKeyUsage &&
+            keyUsage == other.keyUsage
+    }
+
     override fun hashCode(): Int {
         return Objects.hash(keyLength, duration, isSelfSigned, caName, isCa, x500Principal, alternativeNames, extendedKeyUsage, keyUsage)
     }

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/domain/CertificateGenerationParameters.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/domain/CertificateGenerationParameters.kt
@@ -91,7 +91,7 @@ class CertificateGenerationParameters : GenerationParameters {
 
         val that = other as CertificateGenerationParameters?
         return duration == that!!.duration &&
-            equalsIgnoringDuration(that);
+            equalsIgnoringDuration(that)
     }
 
     fun equalsIgnoringDuration(other: CertificateGenerationParameters?): Boolean {

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/services/DefaultCredentialService.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/services/DefaultCredentialService.kt
@@ -128,6 +128,7 @@ class DefaultCredentialService(
         val savedVersion = credentialVersionDataService.save(newVersion)
         if (savedVersion is CertificateCredentialVersion) {
             savedVersion.durationOverridden = (newVersion as CertificateCredentialVersion).durationOverridden
+            savedVersion.durationUsed = newVersion.durationUsed
         }
         return savedVersion
     }

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/services/DefaultCredentialService.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/services/DefaultCredentialService.kt
@@ -125,7 +125,11 @@ class DefaultCredentialService(
             request.generationParameters,
             request.metadata
         )
-        return credentialVersionDataService.save(newVersion)
+        val savedVersion = credentialVersionDataService.save(newVersion)
+        if (savedVersion is CertificateCredentialVersion) {
+            savedVersion.durationOverridden = (newVersion as CertificateCredentialVersion).durationOverridden
+        }
+        return savedVersion
     }
 
     private fun shouldWriteNewCredential(

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/views/CertificateGenerationView.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/views/CertificateGenerationView.kt
@@ -1,0 +1,16 @@
+package org.cloudfoundry.credhub.views
+
+import org.cloudfoundry.credhub.domain.CertificateCredentialVersion
+
+class CertificateGenerationView : CertificateView {
+    var durationOverridden: Boolean = false
+
+    internal constructor() : super() /* Jackson */ {}
+
+    constructor(version: CertificateCredentialVersion, concatenateCas: Boolean) : super(
+        version,
+        concatenateCas
+    ) {
+        durationOverridden = version.durationOverridden
+    }
+}

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/views/CertificateGenerationView.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/views/CertificateGenerationView.kt
@@ -4,6 +4,7 @@ import org.cloudfoundry.credhub.domain.CertificateCredentialVersion
 
 class CertificateGenerationView : CertificateView {
     var durationOverridden: Boolean = false
+    var durationUsed: Int = 0
 
     internal constructor() : super() /* Jackson */ {}
 
@@ -12,5 +13,6 @@ class CertificateGenerationView : CertificateView {
         concatenateCas
     ) {
         durationOverridden = version.durationOverridden
+        durationUsed = version.durationUsed
     }
 }

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/views/CertificateView.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/views/CertificateView.kt
@@ -7,7 +7,7 @@ import org.cloudfoundry.credhub.domain.CertificateCredentialVersion
 import java.time.Instant
 import java.util.Objects
 
-class CertificateView : CredentialView {
+open class CertificateView : CredentialView {
     @JsonIgnore
     private var concatenateCas = false
     private var version: CertificateCredentialVersion? = null
@@ -20,8 +20,6 @@ class CertificateView : CredentialView {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     var generated: Boolean? = null
         private set
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    var durationOverridden: Boolean? = null
 
     internal constructor() : super() /* Jackson */ {}
     constructor(version: CertificateCredentialVersion) : this(
@@ -43,7 +41,6 @@ class CertificateView : CredentialView {
         selfSigned = version.isSelfSigned
         generated = version.generated
         this.concatenateCas = concatenateCas
-        durationOverridden = version.durationOverridden
     }
 
     override var value: CredentialValue?

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/views/CertificateView.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/views/CertificateView.kt
@@ -25,8 +25,8 @@ class CertificateView : CredentialView {
 
     internal constructor() : super() /* Jackson */ {}
     constructor(version: CertificateCredentialVersion) : this(
-            version,
-            false
+        version,
+        false
     )
 
     constructor(version: CertificateCredentialVersion, concatenateCas: Boolean) : super(

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/views/CertificateView.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/views/CertificateView.kt
@@ -20,23 +20,14 @@ class CertificateView : CredentialView {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     var generated: Boolean? = null
         private set
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    var durationOverridden: Boolean? = null
 
     internal constructor() : super() /* Jackson */ {}
-    constructor(version: CertificateCredentialVersion) : super(
-        version.versionCreatedAt,
-        version.uuid,
-        version.name,
-        version.getCredentialType(),
-        version.metadata,
-        null
-    ) {
-        this.version = version
-        expiryDate = version.expiryDate
-        certificateAuthority = version.isCertificateAuthority
-        selfSigned = version.isSelfSigned
-        generated = version.generated
-        concatenateCas = false
-    }
+    constructor(version: CertificateCredentialVersion) : this(
+            version,
+            false
+    )
 
     constructor(version: CertificateCredentialVersion, concatenateCas: Boolean) : super(
         version.versionCreatedAt,
@@ -52,6 +43,7 @@ class CertificateView : CredentialView {
         selfSigned = version.isSelfSigned
         generated = version.generated
         this.concatenateCas = concatenateCas
+        durationOverridden = version.durationOverridden
     }
 
     override var value: CredentialValue?

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/views/CredentialView.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/views/CredentialView.kt
@@ -76,7 +76,7 @@ open class CredentialView {
     companion object {
         @JvmOverloads
         @JvmStatic
-        fun fromEntity(credentialVersion: CredentialVersion?, concatenateCas: Boolean = false): CredentialView {
+        fun fromEntity(credentialVersion: CredentialVersion?, concatenateCas: Boolean = false, includeGenerationInfo: Boolean = false): CredentialView {
             return when (credentialVersion) {
                 is ValueCredentialVersion -> {
                     ValueView((credentialVersion as ValueCredentialVersion?)!!)
@@ -85,7 +85,11 @@ open class CredentialView {
                     PasswordView(credentialVersion)
                 }
                 is CertificateCredentialVersion -> {
-                    CertificateView(credentialVersion, concatenateCas)
+                    if (includeGenerationInfo) {
+                        CertificateGenerationView(credentialVersion, concatenateCas)
+                    } else {
+                        CertificateView(credentialVersion, concatenateCas)
+                    }
                 }
                 is SshCredentialVersion -> {
                     SshView(credentialVersion)

--- a/components/credentials/src/test/java/org/cloudfoundry/credhub/domain/CertificateGenerationParametersTest.java
+++ b/components/credentials/src/test/java/org/cloudfoundry/credhub/domain/CertificateGenerationParametersTest.java
@@ -93,5 +93,50 @@ public class CertificateGenerationParametersTest {
     assertThat(parameters1.equals(parameters2), equalTo(false));
   }
 
+  @Test
+  public void equals_returnsFalseWhenDurationsAreDifferent() throws Exception {
+    final CertificateGenerationRequestParameters requestParameters1 = new CertificateGenerationRequestParameters();
+    requestParameters1.setDuration(365);
+    requestParameters1.setCommonName("a-common-name");
+    final CertificateGenerationRequestParameters requestParameters2 = new CertificateGenerationRequestParameters();
+    requestParameters2.setDuration(730);
+    requestParameters2.setCommonName("a-common-name");
+
+    final CertificateGenerationParameters parameters1 = new CertificateGenerationParameters(requestParameters1);
+    final CertificateGenerationParameters parameters2 = new CertificateGenerationParameters(requestParameters2);
+
+    assertThat(parameters1.equals(parameters2), equalTo(false));
+  }
+
+  @Test
+  public void equalsIgnoringDuration_returnsTrueWhenDurationsAreDifferent() throws Exception {
+    final CertificateGenerationRequestParameters requestParameters1 = new CertificateGenerationRequestParameters();
+    requestParameters1.setDuration(365);
+    requestParameters1.setCommonName("a-common-name");
+    final CertificateGenerationRequestParameters requestParameters2 = new CertificateGenerationRequestParameters();
+    requestParameters2.setDuration(730);
+    requestParameters2.setCommonName("a-common-name");
+
+    final CertificateGenerationParameters parameters1 = new CertificateGenerationParameters(requestParameters1);
+    final CertificateGenerationParameters parameters2 = new CertificateGenerationParameters(requestParameters2);
+
+    assertThat(parameters1.equalsIgnoringDuration(parameters2), equalTo(true));
+  }
+
+  @Test
+  public void equalsIgnoringDuration_returnsFalseWhenCommonNamesAreDifferent() throws Exception {
+    final CertificateGenerationRequestParameters requestParameters1 = new CertificateGenerationRequestParameters();
+    requestParameters1.setDuration(730);
+    requestParameters1.setCommonName("a-common-name");
+    final CertificateGenerationRequestParameters requestParameters2 = new CertificateGenerationRequestParameters();
+    requestParameters2.setDuration(730);
+    requestParameters2.setCommonName("a-common-name2");
+
+    final CertificateGenerationParameters parameters1 = new CertificateGenerationParameters(requestParameters1);
+    final CertificateGenerationParameters parameters2 = new CertificateGenerationParameters(requestParameters2);
+
+    assertThat(parameters1.equalsIgnoringDuration(parameters2), equalTo(false));
+  }
+
 //ParameterizedValidationExceptionTest.java
 }

--- a/components/credentials/src/test/java/org/cloudfoundry/credhub/generators/CertificateGeneratorTest.java
+++ b/components/credentials/src/test/java/org/cloudfoundry/credhub/generators/CertificateGeneratorTest.java
@@ -374,7 +374,7 @@ public class CertificateGeneratorTest {
   public void whenSelfSignIsTrueAndNotCA_itGeneratesAValidSelfSignedCertificateUsingTheLeafMinimumDuration() throws Exception {
     final X509Certificate certificate = new JcaX509CertificateConverter().setProvider(BouncyCastleFipsProvider.PROVIDER_NAME)
             .getCertificate(generateX509SelfSignedCert());
-    final CertificateGenerationParameters expectedParameters = setupMinimumDuration(null, 1460, 365, false, true, 1430);
+    final CertificateGenerationParameters expectedParameters = setupMinimumDuration(null, 1460, 365, false, true, 1460);
     when(keyGenerator.generateKeyPair(anyInt())).thenReturn(rootCaKeyPair);
     when(signedCertificateGenerator.getSelfSigned(rootCaKeyPair, expectedParameters))
             .thenReturn(certificate);
@@ -386,7 +386,7 @@ public class CertificateGeneratorTest {
 
   @Test
   public void whenSelfSignIsFalseAndNotCA_itGeneratesAValidCertificateUsingTheLeafMinimumDuration() throws Exception {
-    final CertificateGenerationParameters expectedParameters = setupMinimumDuration(null, 1460, 365, false, false, 1430);
+    final CertificateGenerationParameters expectedParameters = setupMinimumDuration(null, 1460, 365, false, false, 1460);
     final KeyPair childCertificateKeyPair = setupKeyPair();
     setupMocksForRootCA(childCertificateKeyPair, expectedParameters);
 

--- a/components/credentials/src/test/java/org/cloudfoundry/credhub/generators/CertificateGeneratorTest.java
+++ b/components/credentials/src/test/java/org/cloudfoundry/credhub/generators/CertificateGeneratorTest.java
@@ -79,8 +79,8 @@ public class CertificateGeneratorTest {
       keyGenerator,
       signedCertificateGenerator,
       certificateAuthorityService,
-      null,
-      null
+      0,
+      0
     );
 
 
@@ -350,7 +350,7 @@ public class CertificateGeneratorTest {
   public void whenSelfSignIsTrueAndItIsCA_itGeneratesAValidSelfSignedCertificateUsingTheCaMinimumDuration() throws Exception {
     final X509Certificate certificate = new JcaX509CertificateConverter().setProvider(BouncyCastleFipsProvider.PROVIDER_NAME)
             .getCertificate(generateX509SelfSignedCert());
-    final CertificateGenerationParameters expectedParameters = setupMinimumDuration(3650, null, 365, true, true, 3650);
+    final CertificateGenerationParameters expectedParameters = setupMinimumDuration(3650, 0, 365, true, true, 3650);
     when(keyGenerator.generateKeyPair(anyInt())).thenReturn(rootCaKeyPair);
     when(signedCertificateGenerator.getSelfSigned(rootCaKeyPair, expectedParameters))
       .thenReturn(certificate);
@@ -364,7 +364,7 @@ public class CertificateGeneratorTest {
 
   @Test
   public void whenSelfSignIsFalseAndItIsCA_itGeneratesAValidCertificateUsingTheCaMinimumDuration() throws Exception {
-    final CertificateGenerationParameters expectedParameters = setupMinimumDuration(3650, null, 365, true, false, 3650);
+    final CertificateGenerationParameters expectedParameters = setupMinimumDuration(3650, 0, 365, true, false, 3650);
     final KeyPair childCertificateKeyPair = setupKeyPair();
     setupMocksForRootCA(childCertificateKeyPair, expectedParameters);
 
@@ -380,7 +380,7 @@ public class CertificateGeneratorTest {
   public void whenSelfSignIsTrueAndNotCA_itGeneratesAValidSelfSignedCertificateUsingTheLeafMinimumDuration() throws Exception {
     final X509Certificate certificate = new JcaX509CertificateConverter().setProvider(BouncyCastleFipsProvider.PROVIDER_NAME)
             .getCertificate(generateX509SelfSignedCert());
-    final CertificateGenerationParameters expectedParameters = setupMinimumDuration(null, 1460, 365, false, true, 1460);
+    final CertificateGenerationParameters expectedParameters = setupMinimumDuration(0, 1460, 365, false, true, 1460);
     when(keyGenerator.generateKeyPair(anyInt())).thenReturn(rootCaKeyPair);
     when(signedCertificateGenerator.getSelfSigned(rootCaKeyPair, expectedParameters))
             .thenReturn(certificate);
@@ -394,7 +394,7 @@ public class CertificateGeneratorTest {
 
   @Test
   public void whenSelfSignIsFalseAndNotCA_itGeneratesAValidCertificateUsingTheLeafMinimumDuration() throws Exception {
-    final CertificateGenerationParameters expectedParameters = setupMinimumDuration(null, 1460, 365, false, false, 1460);
+    final CertificateGenerationParameters expectedParameters = setupMinimumDuration(0, 1460, 365, false, false, 1460);
     final KeyPair childCertificateKeyPair = setupKeyPair();
     setupMocksForRootCA(childCertificateKeyPair, expectedParameters);
 
@@ -471,8 +471,8 @@ public class CertificateGeneratorTest {
     return fakeKeyPairGenerator.generate();
   }
 
-  private CertificateGenerationParameters setupMinimumDuration(final Integer caMinimumDuration,
-                                                               final Integer leafMinimumDuration,
+  private CertificateGenerationParameters setupMinimumDuration(final int caMinimumDurationInDays,
+                                                               final int leafMinimumDurationInDays,
                                                                final int defaultDuration,
                                                                final boolean ca,
                                                                final boolean selfSigned,
@@ -481,8 +481,8 @@ public class CertificateGeneratorTest {
             keyGenerator,
             signedCertificateGenerator,
             certificateAuthorityService,
-            caMinimumDuration,
-            leafMinimumDuration
+            caMinimumDurationInDays,
+            leafMinimumDurationInDays
     );
     generationParameters.setCa(ca);
     generationParameters.setSelfSigned(selfSigned);

--- a/components/credentials/src/test/java/org/cloudfoundry/credhub/generators/CertificateGeneratorTest.java
+++ b/components/credentials/src/test/java/org/cloudfoundry/credhub/generators/CertificateGeneratorTest.java
@@ -406,6 +406,20 @@ public class CertificateGeneratorTest {
             equalTo(true));
   }
 
+  @Test
+  public void whenRequestedDurationIsGreaterThanMinimumDuration_itGeneratesAValidCertificateUsingTheRequestedDuration() throws Exception {
+    final CertificateGenerationParameters expectedParameters = setupMinimumDuration(0, 365, 1460, false, false, 1460);
+    final KeyPair childCertificateKeyPair = setupKeyPair();
+    setupMocksForRootCA(childCertificateKeyPair, expectedParameters);
+
+    final CertificateCredentialValue certificateLeaf = subject.generateCredential(inputParameters);
+
+    verify(signedCertificateGenerator, times(1)).
+            getSignedByIssuer(childCertificateKeyPair, expectedParameters, rootCaX509Certificate, rootCaKeyPair.getPrivate());
+    assertThat(certificateLeaf.getDurationOverridden(),
+            equalTo(false));
+  }
+
   private X509CertificateHolder generateX509SelfSignedCert() throws Exception {
     return makeCert(rootCaKeyPair, rootCaKeyPair.getPrivate(), rootCaDn, rootCaDn, false);
   }

--- a/components/credentials/src/test/java/org/cloudfoundry/credhub/generators/CertificateGeneratorTest.java
+++ b/components/credentials/src/test/java/org/cloudfoundry/credhub/generators/CertificateGeneratorTest.java
@@ -320,7 +320,7 @@ public class CertificateGeneratorTest {
     assertThat(certificateCredential.getCa(), equalTo(CertificateFormatter.pemOf(certificate)));
     verify(signedCertificateGenerator, times(1)).getSelfSigned(rootCaKeyPair, inputParameters);
     assertThat(certificateCredential.getDurationOverridden(),
-            equalTo(null));
+            equalTo(false));
   }
 
   @Test

--- a/components/credentials/src/test/java/org/cloudfoundry/credhub/generators/CertificateGeneratorTest.java
+++ b/components/credentials/src/test/java/org/cloudfoundry/credhub/generators/CertificateGeneratorTest.java
@@ -319,6 +319,8 @@ public class CertificateGeneratorTest {
       equalTo(CertificateFormatter.pemOf(certificate)));
     assertThat(certificateCredential.getCa(), equalTo(CertificateFormatter.pemOf(certificate)));
     verify(signedCertificateGenerator, times(1)).getSelfSigned(rootCaKeyPair, inputParameters);
+    assertThat(certificateCredential.getDurationOverridden(),
+            equalTo(null));
   }
 
   @Test
@@ -353,9 +355,11 @@ public class CertificateGeneratorTest {
     when(signedCertificateGenerator.getSelfSigned(rootCaKeyPair, expectedParameters))
       .thenReturn(certificate);
 
-    subject.generateCredential(inputParameters);
+    final CertificateCredentialValue certificateCA = subject.generateCredential(inputParameters);
 
     verify(signedCertificateGenerator, times(1)).getSelfSigned(rootCaKeyPair, expectedParameters);
+    assertThat(certificateCA.getDurationOverridden(),
+            equalTo(true));
   }
 
   @Test
@@ -364,10 +368,12 @@ public class CertificateGeneratorTest {
     final KeyPair childCertificateKeyPair = setupKeyPair();
     setupMocksForRootCA(childCertificateKeyPair, expectedParameters);
 
-    subject.generateCredential(inputParameters);
+    final CertificateCredentialValue certificateCA = subject.generateCredential(inputParameters);
 
     verify(signedCertificateGenerator, times(1)).
       getSignedByIssuer(childCertificateKeyPair, expectedParameters, rootCaX509Certificate, rootCaKeyPair.getPrivate());
+    assertThat(certificateCA.getDurationOverridden(),
+            equalTo(true));
   }
 
   @Test
@@ -379,9 +385,11 @@ public class CertificateGeneratorTest {
     when(signedCertificateGenerator.getSelfSigned(rootCaKeyPair, expectedParameters))
             .thenReturn(certificate);
 
-    subject.generateCredential(inputParameters);
+    final CertificateCredentialValue certificateLeaf = subject.generateCredential(inputParameters);
 
     verify(signedCertificateGenerator, times(1)).getSelfSigned(rootCaKeyPair, expectedParameters);
+    assertThat(certificateLeaf.getDurationOverridden(),
+            equalTo(true));
   }
 
   @Test
@@ -390,10 +398,12 @@ public class CertificateGeneratorTest {
     final KeyPair childCertificateKeyPair = setupKeyPair();
     setupMocksForRootCA(childCertificateKeyPair, expectedParameters);
 
-    subject.generateCredential(inputParameters);
+    final CertificateCredentialValue certificateLeaf = subject.generateCredential(inputParameters);
 
     verify(signedCertificateGenerator, times(1)).
             getSignedByIssuer(childCertificateKeyPair, expectedParameters, rootCaX509Certificate, rootCaKeyPair.getPrivate());
+    assertThat(certificateLeaf.getDurationOverridden(),
+            equalTo(true));
   }
 
   private X509CertificateHolder generateX509SelfSignedCert() throws Exception {

--- a/components/credentials/src/test/java/org/cloudfoundry/credhub/views/CertificateViewTest.java
+++ b/components/credentials/src/test/java/org/cloudfoundry/credhub/views/CertificateViewTest.java
@@ -103,6 +103,7 @@ public class CertificateViewTest {
   @Test
   public void createsAViewFromEntityIncludesDurationOverriddenWhenSet() throws Exception {
     entity.setDurationOverridden(true);
+    entity.setDurationUsed(1234);
     final CredentialView subject = CertificateView.fromEntity(entity, true, true);
     final String actualJson = serializeToString(subject);
 
@@ -121,6 +122,7 @@ public class CertificateViewTest {
             + "\"name\":\"" + credentialName + "\","
             + "\"metadata\":{\"name\":\"test\"},"
             + "\"duration_overridden\":true,"
+            + "\"duration_used\":1234,"
             + "\"value\":{"
             + "\"ca\":\"" + CertificateStringConstants.SELF_SIGNED_CA_CERT + "\","
             + "\"certificate\":\"" + CertificateStringConstants.SIMPLE_SELF_SIGNED_TEST_CERT + "\","

--- a/components/credentials/src/test/java/org/cloudfoundry/credhub/views/CertificateViewTest.java
+++ b/components/credentials/src/test/java/org/cloudfoundry/credhub/views/CertificateViewTest.java
@@ -103,7 +103,7 @@ public class CertificateViewTest {
   @Test
   public void createsAViewFromEntityIncludesDurationOverriddenWhenSet() throws Exception {
     entity.setDurationOverridden(true);
-    final CredentialView subject = CertificateView.fromEntity(entity);
+    final CredentialView subject = CertificateView.fromEntity(entity, true, true);
     final String actualJson = serializeToString(subject);
 
     final Instant expiryDateWithoutMillis = Instant.ofEpochSecond(expiryDate.getEpochSecond());

--- a/components/credentials/src/test/java/org/cloudfoundry/credhub/views/CertificateViewTest.java
+++ b/components/credentials/src/test/java/org/cloudfoundry/credhub/views/CertificateViewTest.java
@@ -101,6 +101,37 @@ public class CertificateViewTest {
   }
 
   @Test
+  public void createsAViewFromEntityIncludesDurationOverriddenWhenSet() throws Exception {
+    entity.setDurationOverridden(true);
+    final CredentialView subject = CertificateView.fromEntity(entity);
+    final String actualJson = serializeToString(subject);
+
+    final Instant expiryDateWithoutMillis = Instant.ofEpochSecond(expiryDate.getEpochSecond());
+    final Instant createdAtWithoutMillis = Instant.ofEpochSecond(createdAt.getEpochSecond());
+
+    final String expectedJson = "{"
+            + "\"type\":\"certificate\","
+            + "\"expiry_date\":\"" + expiryDateWithoutMillis + "\","
+            + "\"transitional\":false,"
+            + "\"certificate_authority\":true,"
+            + "\"self_signed\":false,"
+            + "\"generated\":false,"
+            + "\"version_created_at\":\"" + createdAtWithoutMillis + "\","
+            + "\"id\":\"" + uuid.toString() + "\","
+            + "\"name\":\"" + credentialName + "\","
+            + "\"metadata\":{\"name\":\"test\"},"
+            + "\"duration_overridden\":true,"
+            + "\"value\":{"
+            + "\"ca\":\"" + CertificateStringConstants.SELF_SIGNED_CA_CERT + "\","
+            + "\"certificate\":\"" + CertificateStringConstants.SIMPLE_SELF_SIGNED_TEST_CERT + "\","
+            + "\"private_key\":\"" + CertificateStringConstants.PRIVATE_KEY + "\""
+            + "}"
+            + "}";
+
+    JSONAssert.assertEquals(expectedJson, actualJson, true);
+  }
+
+  @Test
   public void setsUpdatedAtTimeOnGeneratedView() {
     final Instant now = Instant.now();
     entity.setVersionCreatedAt(now);

--- a/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/services/DefaultCredentialServiceTest.kt
+++ b/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/services/DefaultCredentialServiceTest.kt
@@ -474,7 +474,7 @@ class DefaultCredentialServiceTest {
         certificateCredentialVersion.durationOverridden = true
 
         val savedCertificateCredentialVersion = CertificateCredentialVersion(CREDENTIAL_NAME)
-        savedCertificateCredentialVersion.durationOverridden = null
+        savedCertificateCredentialVersion.durationOverridden = false
 
         val originalCredentialVersion = mock(CredentialVersion::class.java)
         `when`(originalCredentialVersion.matchesGenerationParameters(generateRequest.generationParameters)).thenReturn(false)

--- a/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/services/DefaultCredentialServiceTest.kt
+++ b/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/services/DefaultCredentialServiceTest.kt
@@ -461,7 +461,7 @@ class DefaultCredentialServiceTest {
     }
 
     @Test
-    fun save_whenThereIsACertificateOverriddenDurationAndIsSet_ReturnsDurationOverridden() {
+    fun save_whenThereIsACertificateOverriddenDurationAndIsSet_ReturnsDurationOverriddenAndDurationUsed() {
         val generateRequest = mock(BaseCredentialGenerateRequest::class.java)
         `when`(generateRequest.name).thenReturn(CREDENTIAL_NAME)
         `when`(generateRequest.type).thenReturn("certificate")
@@ -472,6 +472,7 @@ class DefaultCredentialServiceTest {
 
         val certificateCredentialVersion = CertificateCredentialVersion(CREDENTIAL_NAME)
         certificateCredentialVersion.durationOverridden = true
+        certificateCredentialVersion.durationUsed = 1234
 
         val savedCertificateCredentialVersion = CertificateCredentialVersion(CREDENTIAL_NAME)
         savedCertificateCredentialVersion.durationOverridden = false
@@ -495,6 +496,7 @@ class DefaultCredentialServiceTest {
 
         val returnedCertificateCredentialVersion = this.subject.save(originalCredentialVersion, certificateCredentialValue, generateRequest) as CertificateCredentialVersion
         assertThat(returnedCertificateCredentialVersion.durationOverridden).isEqualTo(true)
+        assertThat(returnedCertificateCredentialVersion.durationUsed).isEqualTo(1234)
     }
 
     companion object {

--- a/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/services/DefaultCredentialServiceTest.kt
+++ b/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/services/DefaultCredentialServiceTest.kt
@@ -40,7 +40,6 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations.initMocks
-import java.time.Instant
 import java.util.Arrays
 import java.util.UUID
 import java.util.regex.Pattern
@@ -471,7 +470,7 @@ class DefaultCredentialServiceTest {
 
         val certificateCredentialValue = CertificateCredentialValue()
 
-        val certificateCredentialVersion =  CertificateCredentialVersion(CREDENTIAL_NAME)
+        val certificateCredentialVersion = CertificateCredentialVersion(CREDENTIAL_NAME)
         certificateCredentialVersion.durationOverridden = true
 
         val savedCertificateCredentialVersion = CertificateCredentialVersion(CREDENTIAL_NAME)
@@ -480,19 +479,19 @@ class DefaultCredentialServiceTest {
         val originalCredentialVersion = mock(CredentialVersion::class.java)
         `when`(originalCredentialVersion.matchesGenerationParameters(generateRequest.generationParameters)).thenReturn(false)
         `when`(
-                credentialFactory.makeNewCredentialVersion(
-                        CredentialType.valueOf("CERTIFICATE"),
-                        CREDENTIAL_NAME,
-                        certificateCredentialValue,
-                        originalCredentialVersion,
-                        generateRequest.generationParameters,
-                        null
-                )
+            credentialFactory.makeNewCredentialVersion(
+                CredentialType.valueOf("CERTIFICATE"),
+                CREDENTIAL_NAME,
+                certificateCredentialValue,
+                originalCredentialVersion,
+                generateRequest.generationParameters,
+                null
+            )
         ).thenReturn(certificateCredentialVersion)
         `when`(originalCredentialVersion.getCredentialType()).thenReturn("certificate")
 
         `when`(credentialVersionDataService.save(certificateCredentialVersion))
-                .thenReturn(savedCertificateCredentialVersion)
+            .thenReturn(savedCertificateCredentialVersion)
 
         val returnedCertificateCredentialVersion = this.subject.save(originalCredentialVersion, certificateCredentialValue, generateRequest) as CertificateCredentialVersion
         assertThat(returnedCertificateCredentialVersion.durationOverridden).isEqualTo(true)


### PR DESCRIPTION
- Receive 2 new fields in the server configuration file: ca_minimum_duration and leaf_minimum_duration
- Update cert generation/regeneration logic to use the values in these fields such that the cert gets the larger duration between the requested and the new fields
- Update converge mode logic to no longer consider the duration field
- Return a duration_overridden flag in the generate/regenerate API response when the minimum duration is used

For more information, refer this issue: https://github.com/pivotal/credhub-release/issues/60

cc @pabloarodas @ystros