### PR TITLE
API doc improvement

### DIFF
--- a/backends/credhub/src/docs/asciidoc/snippets/certificates-v1.adoc
+++ b/backends/credhub/src/docs/asciidoc/snippets/certificates-v1.adoc
@@ -38,7 +38,7 @@ operation::postCertificatesUuidRegenerateReturnsCertificate[]
 Note:
 
 * If a certificate credential only has one version and it is marked as transitional the credential cannot be regenerated using this endpoint.
-* If the duration used to generate the currently active version of the certificate, or the duration provided via the respective field, is lower than the minimum duration, the regenerated certificate will use the minimum duration instead and the response will contain the `duration_overridden` flag set to true. The duration value used to regenerate the certificate is included in the `duration_used` field of the response.
+* If the duration is overridden by the minimum duration, the response will contain the `duration_overridden` flag set to true. It will also include the actual duration used to regenerate the certificate in the `duration_used` field.
 
 ---
 


### PR DESCRIPTION
- edit for clarity
- the original language:
```
* If the duration used to generate the currently active version of the certificate, or the duration provided via the respective field, is lower than the minimum duration, the regenerated certificate will use the minimum duration instead and the response will contain the `duration_overridden` flag set to true. The duration value used to regenerate the certificate is included in the `duration_used` field of the response.
```
this logic of "if A, or B, then C" where:
* A = the duration used to generate the currently active version of the certificate...is lower than the minimum duration 
* B = the duration provided via the respective field...is lower than the minimum duration 
* C = the regenerated certificate will use the minimum duration instead 

is technically incorrect. For example, if the minimum duration is 200 days, and A involves a duration of 100 days (A is true), B is 300 days (B is false), then eventually what will actually happens is that 300 days will be used, not the minimum duration of 200 days (aka C is false).
  - in reality, B will take precedence over A, so A is ignored
  - And B is not overridden by the minimum duration, as B is compliant, so B will take effect.

* simplify the language to simply say whenever the minimum duration is used, the response will show such. (The logic of how B takes precedence over A is already discussed elsewhere in the doc). 