### PR TITLE
Revert "build(deps): bump springCloudContractVersion from 4.3.1 to 4.3.3"

### DIFF
--- a/applications/credhub-api/build.gradle
+++ b/applications/credhub-api/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springCloudContractVersion = '4.3.3'
+        springCloudContractVersion = '4.3.1'
     }
     repositories {
         def artifactRepoUrl = System.getenv("ARTIFACTORY_URL")


### PR DESCRIPTION
Reverts cloudfoundry/credhub#1081
- To see if the bump is causing the deployment failure in bosh env.