### PR TITLE
Fix: migration hang by disabling Flyway transactional locks early

### DIFF
--- a/applications/credhub-api/src/main/java/org/cloudfoundry/credhub/config/FlywayMigrationStrategyConfiguration.java
+++ b/applications/credhub-api/src/main/java/org/cloudfoundry/credhub/config/FlywayMigrationStrategyConfiguration.java
@@ -7,6 +7,7 @@ import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.database.postgresql.PostgreSQLConfigurationExtension;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
 import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,21 +21,25 @@ public class FlywayMigrationStrategyConfiguration {
     private static final Logger LOGGER = LogManager.getLogger(FlywayMigrationStrategyConfiguration.class.getName());
 
     @Bean
-    public FlywayMigrationStrategy repairBeforeMigration() {
-        return flyway -> {
-            renameMigrationTableIfNeeded(flyway);
-            repairIfNecessary(flyway);
-
-            String url = flyway.getConfiguration().getUrl();
+    public FlywayConfigurationCustomizer postgresFlywayCustomizer() {
+        return configuration -> {
+            String url = configuration.getUrl();
             if (url != null && url.contains("postgresql")) {
                 // For CREATE INDEX CONCURRENTLY. See
                 // https://documentation.red-gate.com/fd/flyway-postgresql-transactional-lock-setting-277579114.html.
-                flyway.getConfigurationExtension(
+                configuration.getConfigurationExtension(
                         PostgreSQLConfigurationExtension.class).setTransactionalLock(
                         false);
                 LOGGER.trace("Set flyway.postgresql.transactional.lock to false.");
             }
+        };
+    }
 
+    @Bean
+    public FlywayMigrationStrategy repairBeforeMigration() {
+        return flyway -> {
+            renameMigrationTableIfNeeded(flyway);
+            repairIfNecessary(flyway);
             runMigration(flyway);
         };
     }

--- a/components/test-support/src/test/java/org/cloudfoundry/credhub/config/FlywayMigrationStrategyTestConfig.java
+++ b/components/test-support/src/test/java/org/cloudfoundry/credhub/config/FlywayMigrationStrategyTestConfig.java
@@ -1,5 +1,6 @@
 package org.cloudfoundry.credhub.config;
 
+import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
 import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,18 +11,24 @@ import org.flywaydb.database.postgresql.PostgreSQLConfigurationExtension;
 
 @Configuration
 public class FlywayMigrationStrategyTestConfig {
+
     @Bean
-    public FlywayMigrationStrategy repairBeforeMigration() {
-        return flyway -> {
-            String url = flyway.getConfiguration().getUrl();
+    public FlywayConfigurationCustomizer postgresFlywayCustomizer() {
+        return configuration -> {
+            String url = configuration.getUrl();
             if (url != null && url.contains("postgresql")) {
                 // For CREATE INDEX CONCURRENTLY. See
                 // https://documentation.red-gate.com/fd/flyway-postgresql-transactional-lock-setting-277579114.html.
-                flyway.getConfigurationExtension(
+                configuration.getConfigurationExtension(
                         PostgreSQLConfigurationExtension.class).setTransactionalLock(
                         false);
             }
+        };
+    }
 
+    @Bean
+    public FlywayMigrationStrategy repairBeforeMigration() {
+        return flyway -> {
             try {
                 flyway.migrate();
             } catch (FlywayException e) {


### PR DESCRIPTION
- With Flyway 12.x, transactional advisory locks are enabled by default for PostgreSQL. These locks are taken during the validation and repair phases and are held throughout the database session. This causes non-transactional migrations using 'CREATE INDEX CONCURRENTLY' (such as V59 and V61) to hang indefinitely, as PostgreSQL does not allow concurrent index creation while other locks are held in the same session.
- The previous programmatic override in the 'FlywayMigrationStrategy' was running too late (after the validation and repair steps had already established a lock). This commit moves the logic to a 'FlywayConfigurationCustomizer', ensuring the transactional lock is disabled before Flyway performs any database operations.
- Changes applied to both the main application and test configurations to ensure consistency across production and CI environments.

ai-assisted=yes
TNZ-93146