### PR TITLE
fix: postgres hangs in bosh director context

### DIFF
--- a/applications/credhub-api/src/main/java/org/cloudfoundry/credhub/config/FlywayMigrationStrategyConfiguration.java
+++ b/applications/credhub-api/src/main/java/org/cloudfoundry/credhub/config/FlywayMigrationStrategyConfiguration.java
@@ -23,15 +23,12 @@ public class FlywayMigrationStrategyConfiguration {
     @Bean
     public FlywayConfigurationCustomizer postgresFlywayCustomizer() {
         return configuration -> {
-            String url = configuration.getUrl();
-            if (url != null && url.contains("postgresql")) {
-                // For CREATE INDEX CONCURRENTLY. See
-                // https://documentation.red-gate.com/fd/flyway-postgresql-transactional-lock-setting-277579114.html.
-                configuration.getConfigurationExtension(
-                        PostgreSQLConfigurationExtension.class).setTransactionalLock(
-                        false);
-                LOGGER.trace("Set flyway.postgresql.transactional.lock to false.");
-            }
+            // For CREATE INDEX CONCURRENTLY. See
+            // https://documentation.red-gate.com/fd/flyway-postgresql-transactional-lock-setting-277579114.html.
+            configuration.getConfigurationExtension(
+                    PostgreSQLConfigurationExtension.class).setTransactionalLock(
+                    false);
+            LOGGER.trace("Set flyway.postgresql.transactional.lock to false via customizer.");
         };
     }
 

--- a/components/test-support/src/test/java/org/cloudfoundry/credhub/config/FlywayMigrationStrategyTestConfig.java
+++ b/components/test-support/src/test/java/org/cloudfoundry/credhub/config/FlywayMigrationStrategyTestConfig.java
@@ -15,14 +15,11 @@ public class FlywayMigrationStrategyTestConfig {
     @Bean
     public FlywayConfigurationCustomizer postgresFlywayCustomizer() {
         return configuration -> {
-            String url = configuration.getUrl();
-            if (url != null && url.contains("postgresql")) {
-                // For CREATE INDEX CONCURRENTLY. See
-                // https://documentation.red-gate.com/fd/flyway-postgresql-transactional-lock-setting-277579114.html.
-                configuration.getConfigurationExtension(
-                        PostgreSQLConfigurationExtension.class).setTransactionalLock(
-                        false);
-            }
+            // For CREATE INDEX CONCURRENTLY. See
+            // https://documentation.red-gate.com/fd/flyway-postgresql-transactional-lock-setting-277579114.html.
+            configuration.getConfigurationExtension(
+                    PostgreSQLConfigurationExtension.class).setTransactionalLock(
+                    false);
         };
     }
 


### PR DESCRIPTION
- Robust Customizer: removed the getUrl() check in FlywayMigrationStrategyConfiguration.java (and the test config). Since the PostgreSQLConfigurationExtension only affects PostgreSQL anyway, we can safely set it without checking the URL.

- problem: Although we moved the logic to a FlywayConfigurationCustomizer (https://github.com/cloudfoundry/credhub/commit/9145c164c26808447357e90cf1cc0297a26b15d8), the implementation had a subtle flaw that caused it to be skipped in the BOSH deployment. In Spring Boot, when a DataSource is provided (which is the case in CredHub within the bosh director context), the FluentConfiguration.getUrl() often returns null because the connection details are encapsulated within the DataSource object rather than being set as a direct JDBC URL string on the Flyway configuration. Consequently, the if block was never executed, and the transactional lock remained enabled (default true).

ai-assisted=yes
TNZ-93146