### PR TITLE
Pin tomcat version to 10.1.54 to fix CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
         protoBufJavaVersion = '4.34.1'
         protoCVersion = '4.34.1'
         jacksonBomVersion = '2.21.1'  // Overriding spring-boot's dependency because flayway 12.1.0 requires later jackson-bom version than spring-boot 3.5.11's
+        tomcatVersion = '10.1.54' // to override version in our current spring-boot version (v3.5.13); can remove this pinning once spring-boot is bumped to a version containing tomcat 10.1.54 or above (see current version: https://github.com/spring-projects/spring-boot/blob/v3.5.13/gradle.properties#L24)
     }
     repositories {
         def artifactRepoUrl = System.getenv("ARTIFACTORY_URL")
@@ -78,5 +79,6 @@ subprojects {
 // Override spring boot's version dependencies
 ext['kotlin.version'] = '${kotlinVersion}'
 ext['jackson-bom.version'] = '${jacksonBomVersion}'
+ext['tomcat.version'] = '${tomcatVersion}'
 
 assert JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)


### PR DESCRIPTION
- to override version in our current spring-boot version (v3.5.13); can remove this pinning once spring-boot is bumped to a version containing tomcat 10.1.54 or above
(see current sprint boot tomcat version:
https://github.com/spring-projects/spring-boot/blob/v3.5.13/gradle.properties#L24)

ai-assisted=no