### PR TITLE
fix: `jdk.tls.namedGroups` jvm property value in Docker start_server.sh

### DIFF
--- a/docker/start_server.sh
+++ b/docker/start_server.sh
@@ -8,7 +8,7 @@ declare -r application_configs
   "-Djava.security.egd=file:/dev/urandom" \
   "-Djdk.tls.ephemeralDHKeySize=4096" \
   "-Dspring.config.additional-location=${application_configs}" \
-  "-Djdk.tls.namedGroups=\"secp384r1\"" \
+  "-Djdk.tls.namedGroups=secp384r1" \
   "-Djavax.net.ssl.trustStore=/app/stores/trust_store.jks" \
   "-Djavax.net.ssl.trustStorePassword=${TRUST_STORE_PASSWORD}" \
   "-ea" \


### PR DESCRIPTION
- The JVM flag was passed with literal quote characters inside the system property value, so Tomcat 10.1.53 logged an unknown TLS group and ECDHE handshakes failed against the CredHub CLI. Use `-Djdk.tls.namedGroups=secp384r1` so the value is only the curve name.
- `docker/start_server.sh` builds argv for `java` as one double-quoted string per argument. Writing `-Djdk.tls.namedGroups=\"secp384r1\"` there put `\"` into the shell string so the JVM saw `"` characters as part of the property value, not as shell quoting. `scripts/start_server.sh` instead passes `-D...` tokens to `gradlew` using normal shell word rules, where `-Djdk.tls.namedGroups="secp384r1"` parses to a single `-D` flag whose value is `secp384r1` without embedded quotes—so the regression was specific to the Docker `java` invocation style.
- In Tomcat 10.1.53 the Connector began using jdk.tls.namedGroups as the default configured group list. See https://tomcat.apache.org/tomcat-10.1-doc/changelog.html (section "Tomcat 10.1.53 (schultz)", bullet starting with "Respect the value for the jdk.tls.namedGroups system property").
- On earlier Tomcat (e.g. 10.1.52) that linkage did not exist, so the same malformed JVM property did not affect that behavior and TLS handshakes still succeeded.
- This fixes https://github.com/pivotal/credhub-release/issues/429.