### PR TITLE
Migrate from JUnit 4 to JUnit 5, replacing the deprecated

### DIFF
--- a/applications/credhub-api/build.gradle
+++ b/applications/credhub-api/build.gradle
@@ -80,7 +80,6 @@ dependencies {
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation('org.springframework.cloud:spring-cloud-starter-contract-verifier')
-    testImplementation("junit:junit")
 }
 
 configurations.all {

--- a/applications/credhub-api/src/test/java/org/cloudfoundry/credhub/config/ActuatorConfigurationTest.java
+++ b/applications/credhub-api/src/test/java/org/cloudfoundry/credhub/config/ActuatorConfigurationTest.java
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -13,15 +13,15 @@ import org.springframework.web.context.WebApplicationContext;
 import org.cloudfoundry.credhub.CredHubApp;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.cloudfoundry.credhub.auth.ActuatorPortFilter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredHubApp.class, properties = {"management.server.port=80"})
 public class ActuatorConfigurationTest {
@@ -34,7 +34,7 @@ public class ActuatorConfigurationTest {
 
   private MockMvc mockMvc;
 
-  @Before
+  @BeforeEach
   public void beforeEach() {
     mockMvc = MockMvcBuilders
       .webAppContextSetup(applicationContext)

--- a/applications/credhub-api/src/test/java/org/cloudfoundry/credhub/config/AuthConfigurationTest.java
+++ b/applications/credhub-api/src/test/java/org/cloudfoundry/credhub/config/AuthConfigurationTest.java
@@ -9,7 +9,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -24,9 +24,9 @@ import org.cloudfoundry.credhub.services.DefaultCredentialVersionDataService;
 import org.cloudfoundry.credhub.domain.CredentialVersion;
 import org.cloudfoundry.credhub.domain.PasswordCredentialVersion;
 import org.cloudfoundry.credhub.utils.CertificateReader;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
 import static org.cloudfoundry.credhub.utils.AuthConstants.INVALID_SCOPE_KEY_JWT;
@@ -39,7 +39,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredHubApp.class)
 @Transactional
@@ -56,7 +56,7 @@ public class AuthConfigurationTest {
 
   private MockMvc mockMvc;
 
-  @Before
+  @BeforeEach
   public void beforeEach() {
     mockMvc = MockMvcBuilders
       .webAppContextSetup(applicationContext)

--- a/applications/credhub-api/src/test/java/org/cloudfoundry/credhub/config/FlywayMigrationStrategyConfigurationTest.java
+++ b/applications/credhub-api/src/test/java/org/cloudfoundry/credhub/config/FlywayMigrationStrategyConfigurationTest.java
@@ -2,14 +2,15 @@ package org.cloudfoundry.credhub.config;
 
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.FlywayException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.sql.*;
 
 import static org.cloudfoundry.credhub.config.DatatabaseLayerImpl.NEW_HISTORY_TABLE_NAME;
 import static org.cloudfoundry.credhub.config.DatatabaseLayerImpl.OLD_HISTORY_TABLE_NAME;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -22,7 +23,7 @@ public class FlywayMigrationStrategyConfigurationTest {
     private ResultSet mockResultSetLegacyTable;
     private ResultSet mockResultSetNewTable;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         instanceToTest = spy(FlywayMigrationStrategyConfiguration.class);
 
@@ -103,11 +104,11 @@ public class FlywayMigrationStrategyConfigurationTest {
         verify(mockFlyway).migrate();
     }
 
-    @Test(expected = FlywayException.class)
+    @Test
     public void handlesGetConnectionException() throws SQLException {
         doThrow(SQLException.class).when(instanceToTest).getConnection(any());
 
-        instanceToTest.renameMigrationTableIfNeeded(mockFlyway);
+        assertThrows(FlywayException.class, () -> instanceToTest.renameMigrationTableIfNeeded(mockFlyway));
     }
 
     @Test

--- a/applications/credhub-api/src/test/kotlin/org/cloudfoundry/credhub/CredhubAppSmokeTest.kt
+++ b/applications/credhub-api/src/test/kotlin/org/cloudfoundry/credhub/CredhubAppSmokeTest.kt
@@ -1,14 +1,14 @@
 package org.cloudfoundry.credhub
 
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.transaction.annotation.Transactional
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @ActiveProfiles(value = ["unit-test"], resolver = DatabaseProfileResolver::class)
 @SpringBootTest(classes = arrayOf(CredHubApp::class))
 @Transactional

--- a/backends/credhub/build.gradle
+++ b/backends/credhub/build.gradle
@@ -61,7 +61,6 @@ dependencies {
     implementation('org.springframework.boot:spring-boot-starter-validation')
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("junit:junit")
 
     implementation('tools.jackson.module:jackson-module-kotlin')
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/db/migration/UserSaltMigrationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/db/migration/UserSaltMigrationTest.java
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 import org.cloudfoundry.credhub.CredhubTestApp;
@@ -19,16 +19,16 @@ import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.cloudfoundry.credhub.utils.UuidUtil;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationVersion;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = {"unit-test", }, resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 public class UserSaltMigrationTest {
@@ -43,7 +43,7 @@ public class UserSaltMigrationTest {
   private String databaseName;
   private List<EncryptionKeyCanary> canaries;
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     canaries = encryptionKeyCanaryRepository.findAll();
 
@@ -65,7 +65,7 @@ public class UserSaltMigrationTest {
     flywayV40.migrate();
   }
 
-  @After
+  @AfterEach
   public void afterEach() {
     flyway.clean();
     flyway.migrate();

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/endToEnd/v2/permissions/AddPermissionsV2EndToEndTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/endToEnd/v2/permissions/AddPermissionsV2EndToEndTest.java
@@ -6,7 +6,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -16,9 +16,9 @@ import org.springframework.web.context.WebApplicationContext;
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.PermissionOperation;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_ACTOR_ID;
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
@@ -31,7 +31,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @ActiveProfiles(
   value = {
@@ -52,7 +52,7 @@ public class AddPermissionsV2EndToEndTest {
 
   private MockMvc mockMvc;
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     applicationEventPublisher.publishEvent(new ContextRefreshedEvent(applicationContext));
     mockMvc = MockMvcBuilders

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/endToEnd/v2/permissions/DeletePermissionsV2EndToEndTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/endToEnd/v2/permissions/DeletePermissionsV2EndToEndTest.java
@@ -9,7 +9,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -23,9 +23,9 @@ import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.cloudfoundry.credhub.views.PermissionsV2View;
 import org.hamcrest.core.IsEqual;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
 import static org.cloudfoundry.credhub.utils.AuthConstants.NO_PERMISSIONS_TOKEN;
@@ -39,7 +39,7 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @ActiveProfiles(
   value = {
@@ -60,7 +60,7 @@ public class DeletePermissionsV2EndToEndTest {
 
   private MockMvc mockMvc;
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     applicationEventPublisher.publishEvent(new ContextRefreshedEvent(applicationContext));
     mockMvc = MockMvcBuilders

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/endToEnd/v2/permissions/GetPermissionsV2EndToEndTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/endToEnd/v2/permissions/GetPermissionsV2EndToEndTest.java
@@ -9,7 +9,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.MessageSource;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -23,9 +23,9 @@ import org.cloudfoundry.credhub.helpers.JsonTestHelper;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.cloudfoundry.credhub.views.PermissionsV2View;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
 import static org.cloudfoundry.credhub.utils.AuthConstants.NO_PERMISSIONS_TOKEN;
@@ -40,7 +40,7 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @ActiveProfiles(
   value = {
@@ -66,7 +66,7 @@ public class GetPermissionsV2EndToEndTest {
 
   private MockMvc mockMvc;
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     applicationEventPublisher.publishEvent(new ContextRefreshedEvent(applicationContext));
     mockMvc = MockMvcBuilders

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/endToEnd/v2/permissions/UpdatePermissionsV2EndToEndTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/endToEnd/v2/permissions/UpdatePermissionsV2EndToEndTest.java
@@ -9,7 +9,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -23,9 +23,9 @@ import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.cloudfoundry.credhub.views.PermissionsV2View;
 import org.hamcrest.core.IsEqual;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
 import static org.cloudfoundry.credhub.utils.AuthConstants.NO_PERMISSIONS_TOKEN;
@@ -40,7 +40,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @ActiveProfiles(
   value = {
@@ -61,7 +61,7 @@ public class UpdatePermissionsV2EndToEndTest {
 
   private MockMvc mockMvc;
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     applicationEventPublisher.publishEvent(new ContextRefreshedEvent(applicationContext));
     mockMvc = MockMvcBuilders

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/handlers/DefaultCertificatesHandlerIntegrationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/handlers/DefaultCertificatesHandlerIntegrationTest.java
@@ -10,23 +10,23 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.JdbcUtils;
 import org.springframework.jdbc.support.MetaDataAccessException;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.certificates.DefaultCertificatesHandler;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.cloudfoundry.credhub.views.CertificateCredentialsView;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
@@ -40,13 +40,14 @@ public class DefaultCertificatesHandlerIntegrationTest {
     @Autowired
     private Environment environment;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
-        Assume.assumeTrue(
-                "Test is for Postgres only",
-                environment.acceptsProfiles(Profiles.of("unit-test-postgres")));
-        Assume.assumeTrue("Test is for Postgres version higher than 10 because the SQL in this test is incompatible with postgres 10",
-                getDatabaseMajorVersion(jdbcTemplate) > 10);
+        Assumptions.assumeTrue(
+                environment.acceptsProfiles(Profiles.of("unit-test-postgres")),
+                "Test is for Postgres only");
+        Assumptions.assumeTrue(
+                getDatabaseMajorVersion(jdbcTemplate) > 10,
+                "Test is for Postgres version higher than 10 because the SQL in this test is incompatible with postgres 10");
 
 
         insertTestCredentialsIntoPostgres(65535 + 1);

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/handlers/DefaultCertificatesHandlerTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/handlers/DefaultCertificatesHandlerTest.java
@@ -44,9 +44,9 @@ import org.cloudfoundry.credhub.views.CertificateVersionView;
 import org.cloudfoundry.credhub.views.CertificateView;
 import org.cloudfoundry.credhub.views.CredentialView;
 import org.hamcrest.core.IsEqual;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -56,8 +56,8 @@ import static org.cloudfoundry.credhub.utils.TestConstants.TEST_CA;
 import static org.cloudfoundry.credhub.utils.TestConstants.TEST_TRUSTED_CA;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -83,12 +83,12 @@ public class DefaultCertificatesHandlerTest {
   private PermissionCheckingService permissionCheckingService;
   private UserContextHolder userContextHolder;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpAll() {
     BouncyCastleFipsConfigurer.configure();
   }
 
-  @Before
+  @BeforeEach
   public void beforeEach() {
     if (Security.getProvider(BouncyCastleFipsProvider.PROVIDER_NAME) == null) {
       Security.addProvider(new BouncyCastleFipsProvider());

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/handlers/DefaultCredentialsHandlerTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/handlers/DefaultCredentialsHandlerTest.java
@@ -46,10 +46,8 @@ import org.cloudfoundry.credhub.views.CredentialView;
 import org.cloudfoundry.credhub.views.DataResponse;
 import org.cloudfoundry.credhub.views.FindCredentialResult;
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import static com.google.common.collect.Lists.newArrayList;
@@ -62,8 +60,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -72,7 +70,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(JUnit4.class)
 public class DefaultCredentialsHandlerTest {
   private static final String CREDENTIAL_NAME = "/test/credential";
   private static final Instant VERSION1_CREATED_AT = Instant.ofEpochMilli(555555555);
@@ -97,7 +94,7 @@ public class DefaultCredentialsHandlerTest {
 
   private Encryptor encryptor;
 
-  @Before
+  @BeforeEach
   public void beforeEach() {
     TestHelper.getBouncyCastleFipsProvider();
     encryptor = mock(Encryptor.class);

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/handlers/DefaultExceptionHandlerTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/handlers/DefaultExceptionHandlerTest.java
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -15,9 +15,9 @@ import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.ErrorMessages;
 import org.cloudfoundry.credhub.credentials.DefaultCredentialsHandler;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
 import static org.mockito.ArgumentMatchers.any;
@@ -30,7 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
@@ -42,7 +42,7 @@ public class DefaultExceptionHandlerTest {
     private WebApplicationContext webApplicationContext;
     private MockMvc mockMvc;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         mockMvc = MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/handlers/DefaultInterpolationHandlerTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/handlers/DefaultInterpolationHandlerTest.java
@@ -20,10 +20,8 @@ import org.cloudfoundry.credhub.services.DefaultCredentialService;
 import org.cloudfoundry.credhub.services.PermissionCheckingService;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.internal.verification.VerificationModeFactory;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
@@ -41,7 +39,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(JUnit4.class)
 public class DefaultInterpolationHandlerTest {
   private static final String UUID_STRING = UUID.randomUUID().toString();
   private static final String USER = "darth-sirius";
@@ -55,7 +52,7 @@ public class DefaultInterpolationHandlerTest {
   private PermissionCheckingService permissionCheckingService;
   private UserContextHolder userContextHolder;
 
-  @Before
+  @BeforeEach
   public void beforeEach() {
     credentialService = mock(DefaultCredentialService.class);
     auditRecord = mock(CEFAuditRecord.class);

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/handlers/DefaultRegenerateHandlerTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/handlers/DefaultRegenerateHandlerTest.java
@@ -38,11 +38,9 @@ import org.cloudfoundry.credhub.views.CertificateValueView;
 import org.cloudfoundry.credhub.views.CredentialView;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -64,7 +62,6 @@ import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 
-@RunWith(JUnit4.class)
 public class DefaultRegenerateHandlerTest {
 
   private static final String SIGNER_NAME = "/signer_name";
@@ -84,11 +81,11 @@ public class DefaultRegenerateHandlerTest {
   private CredentialValue credValue;
   private PermissionCheckingService permissionCheckingService;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpAll() {
     BouncyCastleFipsConfigurer.configure();
   }
-  @Before
+  @BeforeEach
   public void beforeEach() {
     if (Security.getProvider(BouncyCastleFipsProvider.PROVIDER_NAME) == null) {
       Security.addProvider(new BouncyCastleFipsProvider());

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/BulkRegenerateTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/BulkRegenerateTest.java
@@ -10,7 +10,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -24,11 +24,11 @@ import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.helpers.RequestHelper.getCertificateId;
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
@@ -47,7 +47,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(
         value = {
                 "unit-test",
@@ -81,12 +81,12 @@ public class BulkRegenerateTest {
     private String cert1Name;
     private String cert2Name;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeAll() {
         BouncyCastleFipsConfigurer.configure();
     }
 
-    @Before
+    @BeforeEach
     public void beforeEach() throws Exception {
         applicationEventPublisher.publishEvent(new ContextRefreshedEvent(applicationContext));
         mockMvc = MockMvcBuilders
@@ -113,7 +113,7 @@ public class BulkRegenerateTest {
         grantPermissions(otherCertName, USER_A_ACTOR_ID, "read", "write");
     }
 
-    @After
+    @AfterEach
     public void afterEach() {
         credentialVersionRepository.deleteAllInBatch();
     }

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateGenerateTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateGenerateTest.java
@@ -13,7 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -34,12 +34,11 @@ import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.cloudfoundry.credhub.utils.TestConstants;
 import org.hamcrest.Matchers;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import tools.jackson.databind.ObjectMapper;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -64,7 +63,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
+@Timeout(60)
 @ActiveProfiles(
         value = {
                 "unit-test",
@@ -84,15 +84,13 @@ public class CertificateGenerateTest {
     private WebApplicationContext webApplicationContext;
     private MockMvc mockMvc;
 
-    @Rule
-    public Timeout globalTimeout = Timeout.seconds(60);
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeAll() {
         BouncyCastleFipsConfigurer.configure();
     }
 
-    @Before
+    @BeforeEach
     public void beforeEach() {
         mockMvc = MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateGenerateWitDefaultKeyUsagesTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateGenerateWitDefaultKeyUsagesTest.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -27,12 +27,11 @@ import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.bouncycastle.asn1.x509.KeyUsage.cRLSign;
@@ -51,7 +50,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
+@Timeout(60)
 @ActiveProfiles(
         value = {
                 "unit-test",
@@ -68,15 +68,13 @@ public class CertificateGenerateWitDefaultKeyUsagesTest {
   private WebApplicationContext webApplicationContext;
   private MockMvc mockMvc;
 
-  @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() {
     BouncyCastleFipsConfigurer.configure();
   }
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     mockMvc = MockMvcBuilders
       .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateGenerateWithoutAclEnforcementTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateGenerateWithoutAclEnforcementTest.java
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,12 +14,11 @@ import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.helpers.RequestHelper;
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
 import static org.cloudfoundry.credhub.utils.AuthConstants.NO_PERMISSIONS_TOKEN;
@@ -27,7 +26,8 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
+@Timeout(60)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @TestPropertySource(properties = "security.authorization.acls.enabled=false")
@@ -40,15 +40,13 @@ public class CertificateGenerateWithoutAclEnforcementTest {
   private WebApplicationContext webApplicationContext;
   private MockMvc mockMvc;
 
-  @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() {
     BouncyCastleFipsConfigurer.configure();
   }
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     mockMvc = MockMvcBuilders
       .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateGetTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateGetTest.java
@@ -10,7 +10,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -23,12 +23,11 @@ import org.cloudfoundry.credhub.helpers.RequestHelper;
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.json.JSONArray;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.helpers.RequestHelper.generateCa;
 import static org.cloudfoundry.credhub.helpers.RequestHelper.generateCertificateCredential;
@@ -54,7 +53,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
+@Timeout(60)
 @ActiveProfiles(profiles = { "unit-test", "unit-test-permissions", }, resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
@@ -69,15 +69,13 @@ public class CertificateGetTest {
 
   private MockMvc mockMvc;
 
-  @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() {
     BouncyCastleFipsConfigurer.configure();
   }
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     mockMvc = MockMvcBuilders
       .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateMigrationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateMigrationTest.java
@@ -5,7 +5,7 @@ import java.time.Instant;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 import org.cloudfoundry.credhub.CredhubTestApp;
@@ -17,14 +17,14 @@ import org.cloudfoundry.credhub.repositories.CredentialVersionRepository;
 import org.cloudfoundry.credhub.utils.CertificateReader;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.cloudfoundry.credhub.utils.TestConstants;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(
   value = {
     "unit-test",

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateMinimumDurationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateMinimumDurationTest.java
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -28,10 +28,10 @@ import org.cloudfoundry.credhub.repositories.CredentialVersionRepository;
 import org.cloudfoundry.credhub.util.CurrentTimeProvider;
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.TestHelper.mockOutCurrentTimeProvider;
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
@@ -45,7 +45,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(profiles = { "unit-test", "minimum-duration", }, resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
@@ -67,12 +67,12 @@ public class CertificateMinimumDurationTest {
     @Autowired
     private CredentialRepository credentialRepository;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeAll() {
         BouncyCastleFipsConfigurer.configure();
     }
 
-    @Before
+    @BeforeEach
     public void beforeEach() {
         final Consumer<Long> fakeTimeSetter = mockOutCurrentTimeProvider(mockCurrentTimeProvider);
 

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateRegenerateWithDefaultKeyUsagesTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateRegenerateWithDefaultKeyUsagesTest.java
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -24,12 +24,11 @@ import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.cloudfoundry.credhub.utils.TestConstants;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import tools.jackson.databind.ObjectMapper;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -75,12 +74,13 @@ public final class CertificateRegenerateWithDefaultKeyUsagesTest {
     // Utility class - private constructor to prevent instantiation
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() {
     BouncyCastleFipsConfigurer.configure();
   }
 
-  @RunWith(SpringRunner.class)
+  @ExtendWith(SpringExtension.class)
+  @Timeout(60)
   @ActiveProfiles(
           value = {
                   "unit-test",
@@ -98,10 +98,8 @@ public final class CertificateRegenerateWithDefaultKeyUsagesTest {
 
     private MockMvc mockMvc;
 
-    @Rule
-    public Timeout globalTimeout = Timeout.seconds(60);
 
-    @Before
+    @BeforeEach
     public void beforeEach() throws Exception {
       mockMvc = MockMvcBuilders
               .webAppContextSetup(webApplicationContext)
@@ -168,7 +166,8 @@ public final class CertificateRegenerateWithDefaultKeyUsagesTest {
     }
   }
 
-  @RunWith(SpringRunner.class)
+  @ExtendWith(SpringExtension.class)
+  @Timeout(60)
   @ActiveProfiles(
           value = {
                   "unit-test",
@@ -186,10 +185,8 @@ public final class CertificateRegenerateWithDefaultKeyUsagesTest {
 
     private MockMvc mockMvc;
 
-    @Rule
-    public Timeout globalTimeout = Timeout.seconds(60);
 
-    @Before
+    @BeforeEach
     public void beforeEach() throws Exception {
       mockMvc = MockMvcBuilders
               .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateSetAndRegenerateTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateSetAndRegenerateTest.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -25,12 +25,11 @@ import org.cloudfoundry.credhub.helpers.RequestHelper;
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.json.JSONArray;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 import tools.jackson.databind.ObjectMapper;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -48,7 +47,7 @@ import static org.cloudfoundry.credhub.utils.TestConstants.TEST_CERTIFICATE;
 import static org.cloudfoundry.credhub.utils.TestConstants.TEST_PRIVATE_KEY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -59,7 +58,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
+@Timeout(60)
 @ActiveProfiles(value = {"unit-test", "unit-test-permissions", }, resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
@@ -74,15 +74,13 @@ public class CertificateSetAndRegenerateTest {
     private String caCertificate;
     private String caCredentialUuid;
 
-    @Rule
-    public Timeout globalTimeout = Timeout.seconds(60);
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpAll() {
         BouncyCastleFipsConfigurer.configure();
     }
 
-    @Before
+    @BeforeEach
     public void beforeEach() throws Exception {
         mockMvc = MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateUpdateTransitionalVersionTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateUpdateTransitionalVersionTest.java
@@ -3,7 +3,7 @@ package org.cloudfoundry.credhub.integration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -14,18 +14,17 @@ import com.jayway.jsonpath.JsonPath;
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.json.JSONArray;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.helpers.RequestHelper.generateCa;
 import static org.cloudfoundry.credhub.helpers.RequestHelper.getCertificateCredentialsByName;
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -35,7 +34,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
+@Timeout(60)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
@@ -50,10 +50,8 @@ public class CertificateUpdateTransitionalVersionTest {
   private Object caCertificate;
   private String caCredentialUuid;
 
-  @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     mockMvc = MockMvcBuilders
       .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateVersionDeleteTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CertificateVersionDeleteTest.java
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -20,12 +20,11 @@ import org.cloudfoundry.credhub.helpers.RequestHelper;
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.json.JSONArray;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.helpers.RequestHelper.generateCertificateCredential;
 import static org.cloudfoundry.credhub.helpers.RequestHelper.getCertificateCredentialsByName;
@@ -39,7 +38,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
+@Timeout(60)
 @ActiveProfiles(
   value = {
     "unit-test",
@@ -59,15 +59,13 @@ public class CertificateVersionDeleteTest {
 
   private MockMvc mockMvc;
 
-  @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() {
     BouncyCastleFipsConfigurer.configure();
   }
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     mockMvc = MockMvcBuilders
       .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialAclEnforcementTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialAclEnforcementTest.java
@@ -8,7 +8,7 @@ import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -22,10 +22,10 @@ import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.CertificateReader;
 import org.cloudfoundry.credhub.utils.CertificateStringConstants;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
 import static org.cloudfoundry.credhub.utils.AuthConstants.USER_A_ACTOR_ID;
@@ -42,7 +42,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @ActiveProfiles(
   value = {
@@ -65,12 +65,12 @@ public class CredentialAclEnforcementTest {
   private MockMvc mockMvc;
   private String uuid;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() {
     BouncyCastleFipsConfigurer.configure();
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     applicationEventPublisher.publishEvent(new ContextRefreshedEvent(applicationContext));
     mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialDeleteTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialDeleteTest.java
@@ -4,7 +4,7 @@ package org.cloudfoundry.credhub.integration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -14,9 +14,9 @@ import org.springframework.web.context.WebApplicationContext;
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.helpers.RequestHelper;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -26,7 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
@@ -38,7 +38,7 @@ public class CredentialDeleteTest {
 
     private MockMvc mockMvc;
 
-    @Before
+    @BeforeEach
     public void beforeEach() {
         mockMvc = MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialFindTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialFindTest.java
@@ -10,7 +10,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -24,10 +24,10 @@ import org.cloudfoundry.credhub.helpers.JsonTestHelper;
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.cloudfoundry.credhub.views.PermissionsV2View;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.helpers.RequestHelper.generatePassword;
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
@@ -37,7 +37,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -47,7 +47,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(
   value = {
     "unit-test",
@@ -68,12 +68,12 @@ public class CredentialFindTest {
   private WebApplicationContext webApplicationContext;
   private MockMvc mockMvc;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() {
     BouncyCastleFipsConfigurer.configure();
   }
 
-  @Before
+  @BeforeEach
   public void beforeEach() {
     applicationEventPublisher.publishEvent(new ContextRefreshedEvent(applicationContext));
     mockMvc = MockMvcBuilders

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialFindTestNoAcls.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialFindTestNoAcls.java
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -16,9 +16,9 @@ import org.springframework.web.context.WebApplicationContext;
 
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.helpers.RequestHelper.generatePassword;
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
@@ -31,7 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
@@ -43,7 +43,7 @@ public class CredentialFindTestNoAcls {
 
   private MockMvc mockMvc;
 
-  @Before
+  @BeforeEach
   public void beforeEach() {
     mockMvc = MockMvcBuilders
       .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialGetTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialGetTest.java
@@ -10,7 +10,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -23,12 +23,11 @@ import org.cloudfoundry.credhub.helpers.RequestHelper;
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.helpers.RequestHelper.generateCertificateCredential;
 import static org.cloudfoundry.credhub.helpers.RequestHelper.generatePassword;
@@ -44,7 +43,8 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
+@Timeout(60)
 @ActiveProfiles(
   value = {
     "unit-test",
@@ -67,15 +67,13 @@ public class CredentialGetTest {
   @Autowired
   private ApplicationEventPublisher applicationEventPublisher;
 
-  @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() {
     BouncyCastleFipsConfigurer.configure();
   }
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     mockMvc = MockMvcBuilders
       .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialModeSpecificGenerateTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialModeSpecificGenerateTest.java
@@ -3,7 +3,7 @@ package org.cloudfoundry.credhub.integration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,9 +12,9 @@ import org.springframework.web.context.WebApplicationContext;
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.helpers.RequestHelper.generatePassword;
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
@@ -23,7 +23,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsNot.not;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
@@ -35,7 +35,7 @@ public class CredentialModeSpecificGenerateTest {
 
   private MockMvc mockMvc;
 
-  @Before
+  @BeforeEach
   public void setup() {
     mockMvc = MockMvcBuilders
       .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialRegenerateTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialRegenerateTest.java
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -28,10 +28,10 @@ import org.cloudfoundry.credhub.services.CredentialVersionDataService;
 import org.cloudfoundry.credhub.util.CurrentTimeProvider;
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -48,7 +48,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -57,7 +57,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(
   value = {
     "unit-test",
@@ -88,12 +88,12 @@ public class CredentialRegenerateTest {
   private MockMvc mockMvc;
   private Consumer<Long> fakeTimeSetter;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() {
     BouncyCastleFipsConfigurer.configure();
   }
 
-  @Before
+  @BeforeEach
   public void beforeEach() {
     fakeTimeSetter = mockOutCurrentTimeProvider(mockCurrentTimeProvider);
 

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialSetErrorHandlingTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialSetErrorHandlingTest.java
@@ -5,7 +5,7 @@ import java.util.Base64;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -18,9 +18,9 @@ import org.cloudfoundry.credhub.ErrorMessages;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.cloudfoundry.credhub.utils.DatabaseUtilities;
 import org.cloudfoundry.credhub.utils.TestConstants;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import tools.jackson.databind.ObjectMapper;
 
 import static org.cloudfoundry.credhub.helpers.RequestHelper.setPassword;
@@ -35,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
@@ -48,7 +48,7 @@ public class CredentialSetErrorHandlingTest {
 
   private MockMvc mockMvc;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     mockMvc = MockMvcBuilders
       .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/EncryptionKeyRotatorTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/EncryptionKeyRotatorTest.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -46,10 +46,10 @@ import org.cloudfoundry.credhub.services.PasswordKeyProxyFactory;
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.CertificateStringConstants;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import tools.jackson.databind.ObjectMapper;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -72,7 +72,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @Transactional
 public class EncryptionKeyRotatorTest {
 
@@ -107,12 +107,12 @@ public class EncryptionKeyRotatorTest {
   private EncryptionKeyCanary unknownCanary;
   private EncryptionKeyCanary oldCanary;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() {
     BouncyCastleFipsConfigurer.configure();
   }
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     mockMvc = MockMvcBuilders
       .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/GenerateModeTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/GenerateModeTest.java
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -20,10 +20,10 @@ import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.util.CurrentTimeProvider;
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.TestHelper.mockOutCurrentTimeProvider;
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
@@ -40,7 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
@@ -56,12 +56,12 @@ public class GenerateModeTest {
     @Autowired
     private WebApplicationContext webApplicationContext;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeAll() {
         BouncyCastleFipsConfigurer.configure();
     }
 
-    @Before
+    @BeforeEach
     public void beforeEach() {
         final Consumer<Long> fakeTimeSetter = mockOutCurrentTimeProvider(mockCurrentTimeProvider);
 

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/KeyUsageEndpointTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/KeyUsageEndpointTest.java
@@ -3,7 +3,7 @@ package org.cloudfoundry.credhub.integration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -12,9 +12,9 @@ import org.springframework.web.context.WebApplicationContext;
 
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
 import static org.hamcrest.core.IsAnything.anything;
@@ -23,11 +23,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @Transactional
-@Ignore
+@Disabled
 public class KeyUsageEndpointTest {
   @Autowired
   private WebApplicationContext webApplicationContext;

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/LegacyCredentialTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/LegacyCredentialTest.java
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -17,9 +17,9 @@ import org.cloudfoundry.credhub.domain.ValueCredentialVersion;
 import org.cloudfoundry.credhub.entity.ValueCredentialVersionData;
 import org.cloudfoundry.credhub.services.CredentialVersionDataService;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.utils.AuthConstants.NO_PERMISSIONS_TOKEN;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
@@ -27,7 +27,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @ActiveProfiles(
   value = {
@@ -48,7 +48,7 @@ public class LegacyCredentialTest {
   Encryptor encryptor;
   private MockMvc mockMvc;
 
-  @Before
+  @BeforeEach
   public void setup() {
     final ValueCredentialVersionData valueCredentialData = new ValueCredentialVersionData(CREDENTIAL_NAME);
     final ValueCredentialVersion noAclsSecret = new ValueCredentialVersion(valueCredentialData);

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/PasswordRegenerationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/PasswordRegenerationTest.java
@@ -3,7 +3,7 @@ package org.cloudfoundry.credhub.integration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -13,9 +13,9 @@ import org.springframework.web.context.WebApplicationContext;
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -28,7 +28,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
@@ -39,7 +39,7 @@ public class PasswordRegenerationTest {
 
   private MockMvc mockMvc;
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     mockMvc = MockMvcBuilders
       .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/PermissionInitializationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/PermissionInitializationTest.java
@@ -11,7 +11,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 import org.cloudfoundry.credhub.CredhubTestApp;
@@ -27,9 +27,9 @@ import org.cloudfoundry.credhub.services.DefaultCredentialService;
 import org.cloudfoundry.credhub.services.DefaultPermissionService;
 import org.cloudfoundry.credhub.services.PermissionInitializer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -38,7 +38,7 @@ import static org.hamcrest.Matchers.is;
 
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @Transactional
 public class PermissionInitializationTest {
 
@@ -58,7 +58,7 @@ public class PermissionInitializationTest {
   @Autowired
   private ApplicationEventPublisher applicationEventPublisher;
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     final List<AuthorizationConfig.Permission> permissions = new ArrayList<>();
     final AuthorizationConfig.Permission permission = new AuthorizationConfig.Permission();

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/PermissionsEndpointTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/PermissionsEndpointTest.java
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -17,9 +17,9 @@ import org.cloudfoundry.credhub.helpers.RequestHelper;
 import org.cloudfoundry.credhub.requests.PermissionEntry;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.cloudfoundry.credhub.views.PermissionsView;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -44,7 +44,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @ActiveProfiles(
         value = {
@@ -63,7 +63,7 @@ public class PermissionsEndpointTest {
     private final String credentialNameWithoutLeadingSlash = this.getClass().getSimpleName();
     private final String credentialName = "/" + credentialNameWithoutLeadingSlash;
 
-    @Before
+    @BeforeEach
     public void beforeEach() throws Exception {
         mockMvc = MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/PermissionsEndpointWithoutEnforcementTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/PermissionsEndpointWithoutEnforcementTest.java
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -17,9 +17,9 @@ import org.cloudfoundry.credhub.helpers.RequestHelper;
 import org.cloudfoundry.credhub.requests.PermissionEntry;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.cloudfoundry.credhub.views.PermissionsView;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -41,7 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @Transactional
@@ -55,7 +55,7 @@ public class PermissionsEndpointWithoutEnforcementTest {
   private final String credentialNameWithoutLeadingSlash = this.getClass().getSimpleName();
   private final String credentialName = "/" + credentialNameWithoutLeadingSlash;
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     mockMvc = MockMvcBuilders
       .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/PermissionsTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/PermissionsTest.java
@@ -4,15 +4,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.PermissionOperation;
 import org.cloudfoundry.credhub.services.PermissionCheckingService;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_ACTOR_ID;
 import static org.cloudfoundry.credhub.utils.AuthConstants.NO_PERMISSIONS_ACTOR_ID;
@@ -23,7 +23,7 @@ import static org.cloudfoundry.credhub.utils.AuthConstants.USER_B_PATH;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @ActiveProfiles(
         value = {

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/RegenerationEndpointTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/RegenerationEndpointTest.java
@@ -3,7 +3,7 @@ package org.cloudfoundry.credhub.integration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -15,11 +15,10 @@ import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.helpers.RequestHelper;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
 import static org.cloudfoundry.credhub.utils.AuthConstants.NO_PERMISSIONS_TOKEN;
@@ -34,7 +33,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
+@Timeout(60)
 @ActiveProfiles(
   value = {
     "unit-test",
@@ -57,10 +57,8 @@ public class RegenerationEndpointTest {
   private MockMvc mockMvc;
   private String originalPassword;
 
-  @Rule
-  public Timeout globalTimeout = Timeout.seconds(60);
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     mockMvc = MockMvcBuilders
       .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/RsaGenerateTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/RsaGenerateTest.java
@@ -3,7 +3,7 @@ package org.cloudfoundry.credhub.integration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,9 +12,9 @@ import org.springframework.web.context.WebApplicationContext;
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.helpers.RequestHelper.generateRsa;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsNot.not;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
@@ -34,7 +34,7 @@ public class RsaGenerateTest {
 
   private MockMvc mockMvc;
 
-  @Before
+  @BeforeEach
   public void setup() {
     mockMvc = MockMvcBuilders
       .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/SshGenerateTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/SshGenerateTest.java
@@ -3,7 +3,7 @@ package org.cloudfoundry.credhub.integration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,9 +12,9 @@ import org.springframework.web.context.WebApplicationContext;
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.helpers.RequestHelper.generateSsh;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsNot.not;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
@@ -34,7 +34,7 @@ public class SshGenerateTest {
 
   private MockMvc mockMvc;
 
-  @Before
+  @BeforeEach
   public void setup() {
     mockMvc = MockMvcBuilders
       .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/UpdatingACredentialTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/UpdatingACredentialTest.java
@@ -3,7 +3,7 @@ package org.cloudfoundry.credhub.integration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -13,9 +13,9 @@ import org.springframework.web.context.WebApplicationContext;
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -29,7 +29,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(profiles = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
@@ -41,7 +41,7 @@ public class UpdatingACredentialTest {
     private MockMvc mockMvc;
     private String passwordName;
 
-    @Before
+    @BeforeEach
     public void beforeEach() {
         passwordName = "test-password";
 

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/UserGenerationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/UserGenerationTest.java
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -21,9 +21,9 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.apache.commons.lang3.math.NumberUtils.isDigits;
 import static org.cloudfoundry.credhub.helpers.RequestHelper.generateUser;
@@ -41,7 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
@@ -53,7 +53,7 @@ public class UserGenerationTest {
   private WebApplicationContext webApplicationContext;
   private MockMvc mockMvc;
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     mockMvc = MockMvcBuilders
       .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/UserRegenerationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/UserRegenerationTest.java
@@ -3,7 +3,7 @@ package org.cloudfoundry.credhub.integration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -13,9 +13,9 @@ import org.springframework.web.context.WebApplicationContext;
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -28,7 +28,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
@@ -39,7 +39,7 @@ public class UserRegenerationTest {
 
   private MockMvc mockMvc;
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     mockMvc = MockMvcBuilders
       .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/VersionEndpointTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/VersionEndpointTest.java
@@ -3,7 +3,7 @@ package org.cloudfoundry.credhub.integration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -12,8 +12,8 @@ import org.springframework.web.context.WebApplicationContext;
 
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
 import static org.hamcrest.core.IsAnything.anything;
@@ -22,7 +22,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @Transactional

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsGenerateIntegrationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsGenerateIntegrationTest.java
@@ -9,7 +9,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -36,10 +36,10 @@ import org.cloudfoundry.credhub.services.CredentialVersionDataService;
 import org.cloudfoundry.credhub.util.CurrentTimeProvider;
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
 import static org.mockito.ArgumentMatchers.any;
@@ -51,7 +51,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
@@ -90,12 +90,12 @@ public class CredentialsGenerateIntegrationTest {
 
     private MockMvc mockMvc;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeAll() {
         BouncyCastleFipsConfigurer.configure();
     }
 
-    @Before
+    @BeforeEach
     public void beforeEach() {
         final Consumer<Long> fakeTimeSetter = TestHelper.mockOutCurrentTimeProvider(mockCurrentTimeProvider);
 

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsGetIntegrationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsGetIntegrationTest.java
@@ -13,7 +13,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -35,9 +35,9 @@ import org.cloudfoundry.credhub.services.PermissionCheckingService;
 import org.cloudfoundry.credhub.util.CurrentTimeProvider;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.cloudfoundry.credhub.utils.TestConstants;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
@@ -56,7 +56,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(
   value = {
     "unit-test",
@@ -90,7 +90,7 @@ public class CredentialsGetIntegrationTest {
 
   private MockMvc mockMvc;
 
-  @Before
+  @BeforeEach
   public void beforeEach() {
     final Consumer<Long> fakeTimeSetter = TestHelper.mockOutCurrentTimeProvider(mockCurrentTimeProvider);
 

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsTypeSpecificGenerateIntegrationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsTypeSpecificGenerateIntegrationTest.java
@@ -12,8 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
-import org.springframework.test.context.junit4.rules.SpringClassRule;
-import org.springframework.test.context.junit4.rules.SpringMethodRule;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.ResultMatcher;
@@ -52,13 +51,11 @@ import org.cloudfoundry.credhub.util.CurrentTimeProvider;
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.cloudfoundry.credhub.utils.MultiJsonPathMatcher;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import tools.jackson.databind.ObjectMapper;
@@ -66,7 +63,7 @@ import tools.jackson.databind.ObjectMapper;
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -80,14 +77,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(Parameterized.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
 public class CredentialsTypeSpecificGenerateIntegrationTest {
-
-  @ClassRule
-  public static final SpringClassRule SPRING_CLASS_RULE = new SpringClassRule();
   private static final String RSA_PUBLIC_KEY =
     "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3jegX4fdAWXKAH1OVme8"
       + "uqG/2lU/f6ABRoHSk3tyHnaiIpxOfaNqi4iD0InYgYbuS5+CwCfJuRdL9XPQQ58x"
@@ -209,10 +203,6 @@ public class CredentialsTypeSpecificGenerateIntegrationTest {
   private static final String FINGER_PRINT = "Px23DxgJx1+P7gAtzV7S2/cvWyRDn7GfCRvx7VUkzoY";
   private static final Instant FROZEN_TIME = Instant.ofEpochSecond(1400011001L);
   private static UUID credentialUuid;
-  @Rule
-  public final SpringMethodRule springMethodRule = new SpringMethodRule();
-  @Parameterized.Parameter
-  public TestParameterizer parametizer;
   @Autowired
   private WebApplicationContext webApplicationContext;
   @MockitoSpyBean
@@ -237,10 +227,9 @@ public class CredentialsTypeSpecificGenerateIntegrationTest {
   private CryptSaltFactory cryptSaltFactory;
   private MockMvc mockMvc;
 
-  @Parameterized.Parameters(name = "{0}")
-  public static Collection<Object> parameters() {
+  static Collection<TestParameterizer> parameters() {
     credentialUuid = UUID.randomUUID();
-    final Collection<Object> params = new ArrayList<>();
+    final Collection<TestParameterizer> params = new ArrayList<>();
 
     final TestParameterizer passwordParameters = new TestParameterizer("password", "{\"exclude_number\": true}") {
       @Override
@@ -400,12 +389,12 @@ public class CredentialsTypeSpecificGenerateIntegrationTest {
     return params;
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() {
     BouncyCastleFipsConfigurer.configure();
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     final String fakeSalt = cryptSaltFactory.generateSalt(FAKE_PASSWORD);
     final Consumer<Long> fakeTimeSetter = TestHelper.mockOutCurrentTimeProvider(mockCurrentTimeProvider);
@@ -433,9 +422,10 @@ public class CredentialsTypeSpecificGenerateIntegrationTest {
   }
 
 
-  @Test
-  public void generatingACredential_validatesTheRequestBody() throws Exception {
-    final MockHttpServletRequestBuilder request = createGenerateNewCredentialRequest();
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void generatingACredential_validatesTheRequestBody(TestParameterizer parametizer) throws Exception {
+    final MockHttpServletRequestBuilder request = createGenerateNewCredentialRequest(parametizer);
 
     final DefaultCredentialGenerateRequest requestBody = mock(DefaultCredentialGenerateRequest.class);
 
@@ -448,8 +438,9 @@ public class CredentialsTypeSpecificGenerateIntegrationTest {
         "{\"error\":\"The request could not be fulfilled because the request path or body did not meet expectation. Please check the documentation for required formatting and retry your request.\"}"));
   }
 
-  @Test
-  public void shouldAcceptAnyCasingForType() throws Exception {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void shouldAcceptAnyCasingForType(TestParameterizer parametizer) throws Exception {
     final MockHttpServletRequestBuilder request = post("/api/v1/data")
       .header("Authorization", "Bearer " + ALL_PERMISSIONS_TOKEN)
       .accept(APPLICATION_JSON)
@@ -471,10 +462,11 @@ public class CredentialsTypeSpecificGenerateIntegrationTest {
       );
   }
 
-  @Test
-  public void generatingANewCredential_shouldReturnGeneratedCredentialAndAskDataServiceToPersistTheCredential()
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void generatingANewCredential_shouldReturnGeneratedCredentialAndAskDataServiceToPersistTheCredential(TestParameterizer parametizer)
     throws Exception {
-    final MockHttpServletRequestBuilder request = createGenerateNewCredentialRequest();
+    final MockHttpServletRequestBuilder request = createGenerateNewCredentialRequest(parametizer);
 
     final ResultActions response = mockMvc.perform(request);
 
@@ -494,10 +486,11 @@ public class CredentialsTypeSpecificGenerateIntegrationTest {
       .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON));
   }
 
-  @Test
-  public void generatingANewCredentialVersion_withOverwrite_shouldGenerateANewCredential() throws Exception {
-    beforeEachExistingCredential();
-    final MockHttpServletRequestBuilder request = beforeEachOverwriteSetToTrue();
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void generatingANewCredentialVersion_withOverwrite_shouldGenerateANewCredential(TestParameterizer parametizer) throws Exception {
+    beforeEachExistingCredential(parametizer);
+    final MockHttpServletRequestBuilder request = beforeEachOverwriteSetToTrue(parametizer);
 
     final ResultActions response = mockMvc.perform(request);
 
@@ -517,10 +510,11 @@ public class CredentialsTypeSpecificGenerateIntegrationTest {
         "$.version_created_at", FROZEN_TIME.toString()));
   }
 
-  @Test
-  public void generatingANewCredentialVersion_withOverwrite_shouldPersistTheNewCredential() throws Exception {
-    beforeEachExistingCredential();
-    final MockHttpServletRequestBuilder request = beforeEachOverwriteSetToTrue();
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void generatingANewCredentialVersion_withOverwrite_shouldPersistTheNewCredential(TestParameterizer parametizer) throws Exception {
+    beforeEachExistingCredential(parametizer);
+    final MockHttpServletRequestBuilder request = beforeEachOverwriteSetToTrue(parametizer);
 
     mockMvc.perform(request);
 
@@ -528,10 +522,11 @@ public class CredentialsTypeSpecificGenerateIntegrationTest {
     parametizer.credentialAssertions(credentialVersion);
   }
 
-  @Test
-  public void generatingANewCredentialVersion_withOverwriteFalse_returnsThePreviousVersion_whenParametersAreTheSame() throws Exception {
-    beforeEachExistingCredential();
-    final MockHttpServletRequestBuilder request = beforeEachOverwriteSetToFalse();
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void generatingANewCredentialVersion_withOverwriteFalse_returnsThePreviousVersion_whenParametersAreTheSame(TestParameterizer parametizer) throws Exception {
+    beforeEachExistingCredential(parametizer);
+    final MockHttpServletRequestBuilder request = beforeEachOverwriteSetToFalse(parametizer);
 
     mockMvc.perform(request)
       .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
@@ -542,17 +537,18 @@ public class CredentialsTypeSpecificGenerateIntegrationTest {
         "$.version_created_at", FROZEN_TIME.minusSeconds(1).toString()));
   }
 
-  @Test
-  public void generatingANewCredentialVersion_withOverwriteFalse_doesNotPersistANewVersion_whenParametersAreTheSame() throws Exception {
-    beforeEachExistingCredential();
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void generatingANewCredentialVersion_withOverwriteFalse_doesNotPersistANewVersion_whenParametersAreTheSame(TestParameterizer parametizer) throws Exception {
+    beforeEachExistingCredential(parametizer);
 
-    final MockHttpServletRequestBuilder request = beforeEachOverwriteSetToFalse();
+    final MockHttpServletRequestBuilder request = beforeEachOverwriteSetToFalse(parametizer);
     mockMvc.perform(request);
 
     verify(credentialVersionDataService, times(0)).save(any(CredentialVersion.class));
   }
 
-  private MockHttpServletRequestBuilder createGenerateNewCredentialRequest() {
+  private MockHttpServletRequestBuilder createGenerateNewCredentialRequest(TestParameterizer parametizer) {
     return post("/api/v1/data")
       .header("Authorization", "Bearer " + ALL_PERMISSIONS_TOKEN)
       .accept(APPLICATION_JSON)
@@ -565,7 +561,7 @@ public class CredentialsTypeSpecificGenerateIntegrationTest {
         "}");
   }
 
-  private void beforeEachExistingCredential() {
+  private void beforeEachExistingCredential(TestParameterizer parametizer) {
     CredentialVersion credentialVersion = parametizer.createCredential(encryptor);
     doReturn(Collections.singletonList(credentialVersion))
       .when(credentialVersionDataService)
@@ -575,7 +571,7 @@ public class CredentialsTypeSpecificGenerateIntegrationTest {
       .findMostRecent(CREDENTIAL_NAME);
   }
 
-  private MockHttpServletRequestBuilder beforeEachOverwriteSetToTrue() {
+  private MockHttpServletRequestBuilder beforeEachOverwriteSetToTrue(TestParameterizer parametizer) {
     return post("/api/v1/data")
       .header("Authorization", "Bearer " + ALL_PERMISSIONS_TOKEN)
       .accept(APPLICATION_JSON)
@@ -588,7 +584,7 @@ public class CredentialsTypeSpecificGenerateIntegrationTest {
         "}");
   }
 
-  private MockHttpServletRequestBuilder beforeEachOverwriteSetToFalse() {
+  private MockHttpServletRequestBuilder beforeEachOverwriteSetToFalse(TestParameterizer parametizer) {
     return post("/api/v1/data")
       .header("Authorization", "Bearer " + ALL_PERMISSIONS_TOKEN)
       .accept(APPLICATION_JSON)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsTypeSpecificSetIntegrationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsTypeSpecificSetIntegrationTest.java
@@ -12,8 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
-import org.springframework.test.context.junit4.rules.SpringClassRule;
-import org.springframework.test.context.junit4.rules.SpringMethodRule;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.ResultMatcher;
@@ -41,12 +40,10 @@ import org.cloudfoundry.credhub.util.CurrentTimeProvider;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.cloudfoundry.credhub.utils.MultiJsonPathMatcher;
 import org.cloudfoundry.credhub.utils.TestConstants;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
@@ -55,7 +52,7 @@ import tools.jackson.databind.ObjectMapper;
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
@@ -66,13 +63,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(Parameterized.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
 public class CredentialsTypeSpecificSetIntegrationTest {
-  @ClassRule
-  public static final SpringClassRule SPRING_CLASS_RULE = new SpringClassRule();
   private static final Instant FROZEN_TIME = Instant.ofEpochSecond(1400011001L);
   private static final String CREDENTIAL_NAME = "/my-namespace/subTree/credential-name";
   private static final ImmutableMap<String, Integer> nestedValue = ImmutableMap.<String, Integer>builder()
@@ -152,10 +147,6 @@ public class CredentialsTypeSpecificSetIntegrationTest {
 
   private static final JsonNode jsonNode = new ObjectMapper().readTree(JSON_VALUE_JSON_STRING);
 
-  @Rule
-  public final SpringMethodRule springMethodRule = new SpringMethodRule();
-  @Parameterized.Parameter
-  public TestParametizer parametizer;
   @Autowired
   private WebApplicationContext webApplicationContext;
   @MockitoSpyBean
@@ -170,11 +161,10 @@ public class CredentialsTypeSpecificSetIntegrationTest {
   private Encryptor encryptor;
   private MockMvc mockMvc;
 
-  @Parameterized.Parameters(name = "{0}")
-  public static Collection<Object> parameters() {
+  static Collection<TestParametizer> parameters() {
     final UUID credentialUuid = UUID.randomUUID();
 
-    final Collection<Object> params = new ArrayList<>();
+    final Collection<TestParametizer> params = new ArrayList<>();
 
     final TestParametizer valueParameters = new TestParametizer("value", "\"" + VALUE_VALUE + "\"") {
       @Override
@@ -371,7 +361,7 @@ public class CredentialsTypeSpecificSetIntegrationTest {
     return params;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     final Consumer<Long> fakeTimeSetter = TestHelper.mockOutCurrentTimeProvider(mockCurrentTimeProvider);
 
@@ -382,8 +372,9 @@ public class CredentialsTypeSpecificSetIntegrationTest {
       .build();
   }
 
-  @Test
-  public void settingACredential_shouldAcceptAnyCasingForType() throws Exception {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void settingACredential_shouldAcceptAnyCasingForType(TestParametizer parametizer) throws Exception {
     final MockHttpServletRequestBuilder request = put("/api/v1/data")
       .header("Authorization", "Bearer " + ALL_PERMISSIONS_TOKEN)
       .accept(APPLICATION_JSON)
@@ -413,8 +404,9 @@ public class CredentialsTypeSpecificSetIntegrationTest {
       .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON));
   }
 
-  @Test
-  public void settingACredential_returnsTheExpectedResponse() throws Exception {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void settingACredential_returnsTheExpectedResponse(TestParametizer parametizer) throws Exception {
     final MockHttpServletRequestBuilder request = put("/api/v1/data")
       .header("Authorization", "Bearer " + ALL_PERMISSIONS_TOKEN)
       .accept(APPLICATION_JSON)
@@ -442,8 +434,9 @@ public class CredentialsTypeSpecificSetIntegrationTest {
       .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON));
   }
 
-  @Test
-  public void settingACredential_expectsDataServiceToPersistTheCredential() throws Exception {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void settingACredential_expectsDataServiceToPersistTheCredential(TestParametizer parametizer) throws Exception {
     final MockHttpServletRequestBuilder request = put("/api/v1/data")
       .header("Authorization", "Bearer " + ALL_PERMISSIONS_TOKEN)
       .accept(APPLICATION_JSON)
@@ -466,8 +459,9 @@ public class CredentialsTypeSpecificSetIntegrationTest {
     parametizer.credentialAssertions(newCredentialVersion);
   }
 
-  @Test
-  public void validationExceptionsAreReturnedAsErrorMessages() throws Exception {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void validationExceptionsAreReturnedAsErrorMessages(TestParametizer parametizer) throws Exception {
     final MockHttpServletRequestBuilder request = put("/api/v1/data")
       .header("Authorization", "Bearer " + ALL_PERMISSIONS_TOKEN)
       .accept(APPLICATION_JSON)
@@ -483,8 +477,9 @@ public class CredentialsTypeSpecificSetIntegrationTest {
       .andExpect(content().json("{\"error\":\"The request could not be fulfilled because the request path or body did not meet expectation. Please check the documentation for required formatting and retry your request.\"}"));
   }
 
-  @Test
-  public void updatingACredential_returnsTheExistingCredentialVersion() throws Exception {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void updatingACredential_returnsTheExistingCredentialVersion(TestParametizer parametizer) throws Exception {
     doReturn(parametizer.createCredential(encryptor)).when(credentialVersionDataService).findMostRecent(CREDENTIAL_NAME);
 
     final MockHttpServletRequestBuilder put = put("/api/v1/data")
@@ -514,8 +509,9 @@ public class CredentialsTypeSpecificSetIntegrationTest {
         "$.version_created_at", FROZEN_TIME.toString()));
   }
 
-  @Test
-  public void updatingACredential_persistsTheCredential() throws Exception {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void updatingACredential_persistsTheCredential(TestParametizer parametizer) throws Exception {
     doReturn(parametizer.createCredential(encryptor)).when(credentialVersionDataService).findMostRecent(CREDENTIAL_NAME);
 
     final MockHttpServletRequestBuilder put = put("/api/v1/data")

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/interpolation/InterpolationIntegrationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/interpolation/InterpolationIntegrationTest.java
@@ -9,7 +9,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -21,9 +21,9 @@ import org.cloudfoundry.credhub.domain.JsonCredentialVersion;
 import org.cloudfoundry.credhub.domain.ValueCredentialVersion;
 import org.cloudfoundry.credhub.services.CredentialVersionDataService;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -40,7 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional
@@ -53,7 +53,7 @@ public class InterpolationIntegrationTest {
 
   private MockMvc mockMvc;
 
-  @Before
+  @BeforeEach
   public void beforeEach() {
     mockMvc = MockMvcBuilders
       .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/management/ManagementIntegrationTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/v1/management/ManagementIntegrationTest.java
@@ -5,7 +5,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -14,9 +14,9 @@ import org.springframework.web.context.WebApplicationContext;
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.ManagementRegistry;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.cloudfoundry.credhub.utils.AuthConstants.ALL_PERMISSIONS_TOKEN;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -28,7 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @TestPropertySource(properties = "security.authorization.acls.enabled=false")
@@ -42,7 +42,7 @@ public class ManagementIntegrationTest {
 
   private MockMvc mockMvc;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     mockMvc = MockMvcBuilders
       .webAppContextSetup(webApplicationContext)

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/certificates/CertificatesControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/certificates/CertificatesControllerTest.kt
@@ -21,10 +21,10 @@ import org.cloudfoundry.credhub.views.CertificateGenerationView
 import org.cloudfoundry.credhub.views.CertificateVersionView
 import org.cloudfoundry.credhub.views.CertificateView
 import org.cloudfoundry.credhub.views.CredentialView
-import org.junit.After
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType
 import org.springframework.restdocs.ManualRestDocumentation
@@ -65,14 +65,14 @@ class CertificatesControllerTest {
     private lateinit var metadata: JsonNode
 
     companion object {
-        @BeforeClass
+        @BeforeAll
         @JvmStatic
         fun setUpAll() {
             BouncyCastleFipsConfigurer.configure()
         }
     }
 
-    @Before
+    @BeforeEach
     fun setUp() {
         restDocumentation.beforeTest(javaClass, javaClass.simpleName)
         spyCertificatesHandler = SpyCertificatesHandler()
@@ -115,7 +115,7 @@ class CertificatesControllerTest {
         certificateView = CertificateView(certificateCredentialVersion)
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         restDocumentation.afterTest()
     }

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerDeleteTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerDeleteTest.kt
@@ -9,10 +9,10 @@ import org.cloudfoundry.credhub.helpers.CredHubRestDocs
 import org.cloudfoundry.credhub.helpers.MockMvcFactory
 import org.cloudfoundry.credhub.helpers.credHubAuthHeader
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
-import org.junit.After
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.restdocs.ManualRestDocumentation
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
@@ -33,14 +33,14 @@ class CredentialsControllerDeleteTest {
     private val objectMapper: JsonMapper = JsonMapper.builder().build()
 
     companion object {
-        @BeforeClass
+        @BeforeAll
         @JvmStatic
         fun setUpAll() {
             BouncyCastleFipsConfigurer.configure()
         }
     }
 
-    @Before
+    @BeforeEach
     fun setUp() {
         restDocumentation.beforeTest(javaClass, javaClass.simpleName)
         val credentialController =
@@ -57,7 +57,7 @@ class CredentialsControllerDeleteTest {
         }
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         restDocumentation.afterTest()
     }

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerGenerateTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerGenerateTest.kt
@@ -25,11 +25,11 @@ import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
 import org.cloudfoundry.credhub.utils.TestConstants
 import org.cloudfoundry.credhub.views.CertificateGenerationView
 import org.cloudfoundry.credhub.views.CredentialView
-import org.junit.After
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
 import org.skyscreamer.jsonassert.JSONAssert
@@ -42,7 +42,7 @@ import org.springframework.restdocs.payload.PayloadDocumentation
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
 import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
 import org.springframework.restdocs.payload.RequestFieldsSnippet
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -53,7 +53,7 @@ import java.security.Security
 import java.time.Instant
 import java.util.UUID
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 class CredentialsControllerGenerateTest {
     private val restDocumentation = ManualRestDocumentation()
     val uuid = UUID.randomUUID()
@@ -70,14 +70,14 @@ class CredentialsControllerGenerateTest {
     lateinit var metadata: JsonNode
 
     companion object {
-        @BeforeClass
+        @BeforeAll
         @JvmStatic
         fun setUpAll() {
             BouncyCastleFipsConfigurer.configure()
         }
     }
 
-    @Before
+    @BeforeEach
     fun setUp() {
         restDocumentation.beforeTest(javaClass, javaClass.simpleName)
 
@@ -97,7 +97,7 @@ class CredentialsControllerGenerateTest {
         }
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         restDocumentation.afterTest()
     }

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerGetTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerGetTest.kt
@@ -20,11 +20,11 @@ import org.cloudfoundry.credhub.utils.TestConstants
 import org.cloudfoundry.credhub.views.CredentialView
 import org.cloudfoundry.credhub.views.DataResponse
 import org.cloudfoundry.credhub.views.FindCredentialResult
-import org.junit.After
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType
 import org.springframework.restdocs.ManualRestDocumentation
@@ -33,7 +33,7 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get
 import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
 import org.springframework.restdocs.request.RequestDocumentation.pathParameters
 import org.springframework.restdocs.request.RequestDocumentation.queryParameters
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -43,7 +43,7 @@ import java.security.Security
 import java.time.Instant
 import java.util.UUID
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 class CredentialsControllerGetTest {
     private val restDocumentation = ManualRestDocumentation()
     val uuid = UUID.randomUUID()
@@ -55,14 +55,14 @@ class CredentialsControllerGetTest {
     lateinit var metadata: JsonNode
 
     companion object {
-        @BeforeClass
+        @BeforeAll
         @JvmStatic
         fun setUpAll() {
             BouncyCastleFipsConfigurer.configure()
         }
     }
 
-    @Before
+    @BeforeEach
     fun setUp() {
         restDocumentation.beforeTest(javaClass, javaClass.simpleName)
         spyCredentialsHandler = SpyCredentialsHandler()
@@ -85,7 +85,7 @@ class CredentialsControllerGetTest {
         }
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         restDocumentation.afterTest()
     }

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerSetTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerSetTest.kt
@@ -26,11 +26,11 @@ import org.cloudfoundry.credhub.requests.ValueSetRequest
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
 import org.cloudfoundry.credhub.utils.TestConstants
 import org.cloudfoundry.credhub.views.CredentialView
-import org.junit.After
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType
 import org.springframework.restdocs.ManualRestDocumentation
@@ -40,7 +40,7 @@ import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
 import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
 import org.springframework.restdocs.payload.RequestFieldsSnippet
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -50,7 +50,7 @@ import java.security.Security
 import java.time.Instant
 import java.util.UUID
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 class CredentialsControllerSetTest {
     private val restDocumentation = ManualRestDocumentation()
     val uuid = UUID.randomUUID()
@@ -62,14 +62,14 @@ class CredentialsControllerSetTest {
     lateinit var metadata: JsonNode
 
     companion object {
-        @BeforeClass
+        @BeforeAll
         @JvmStatic
         fun setUpAll() {
             BouncyCastleFipsConfigurer.configure()
         }
     }
 
-    @Before
+    @BeforeEach
     fun setUp() {
         restDocumentation.beforeTest(javaClass, javaClass.simpleName)
         val credentialController =
@@ -89,7 +89,7 @@ class CredentialsControllerSetTest {
         }
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         restDocumentation.afterTest()
     }

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/health/HealthControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/health/HealthControllerTest.kt
@@ -3,14 +3,14 @@ package org.cloudfoundry.credhub.controllers.v1.health
 import org.cloudfoundry.credhub.health.HealthController
 import org.cloudfoundry.credhub.helpers.CredHubRestDocs
 import org.cloudfoundry.credhub.helpers.MockMvcFactory
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.restdocs.ManualRestDocumentation
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -18,14 +18,14 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @Deprecated(
     message = "No longer needed after CredHub 2.2 because we have Spring Actuator",
 )
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 class HealthControllerTest {
     private val restDocumentation = ManualRestDocumentation()
 
     private lateinit var mockMvc: MockMvc
     private lateinit var healthController: HealthController
 
-    @Before
+    @BeforeEach
     fun setUp() {
         restDocumentation.beforeTest(javaClass, javaClass.simpleName)
         healthController = HealthController()
@@ -38,7 +38,7 @@ class HealthControllerTest {
             )
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         restDocumentation.afterTest()
     }

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/info/InfoControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/info/InfoControllerTest.kt
@@ -6,23 +6,23 @@ import org.cloudfoundry.credhub.helpers.MockMvcFactory
 import org.cloudfoundry.credhub.helpers.credHubAuthHeader
 import org.cloudfoundry.credhub.info.InfoController
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
-import org.junit.After
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType
 import org.springframework.restdocs.ManualRestDocumentation
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.security.Security
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 class InfoControllerTest {
     private val restDocumentation = ManualRestDocumentation()
 
@@ -30,14 +30,14 @@ class InfoControllerTest {
     lateinit var uaaUrl: String
 
     companion object {
-        @BeforeClass
+        @BeforeAll
         @JvmStatic
         fun setUpAll() {
             BouncyCastleFipsConfigurer.configure()
         }
     }
 
-    @Before
+    @BeforeEach
     fun setUp() {
         restDocumentation.beforeTest(javaClass, javaClass.simpleName)
         uaaUrl = "https://uaa.url.example.com"
@@ -51,7 +51,7 @@ class InfoControllerTest {
         }
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         restDocumentation.afterTest()
     }

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/interpolate/InterpolateControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/interpolate/InterpolateControllerTest.kt
@@ -8,10 +8,10 @@ import org.cloudfoundry.credhub.helpers.MockMvcFactory
 import org.cloudfoundry.credhub.helpers.credHubAuthHeader
 import org.cloudfoundry.credhub.interpolation.InterpolationController
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
-import org.junit.After
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType
 import org.springframework.restdocs.ManualRestDocumentation
@@ -30,14 +30,14 @@ class InterpolateControllerTest {
     lateinit var spyInterpolationHandler: SpyInterpolationHandler
 
     companion object {
-        @BeforeClass
+        @BeforeAll
         @JvmStatic
         fun setUpAll() {
             BouncyCastleFipsConfigurer.configure()
         }
     }
 
-    @Before
+    @BeforeEach
     fun setUp() {
         restDocumentation.beforeTest(javaClass, javaClass.simpleName)
         spyInterpolationHandler = SpyInterpolationHandler()
@@ -55,7 +55,7 @@ class InterpolateControllerTest {
         }
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         restDocumentation.afterTest()
     }

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/keyusage/KeyUsageControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/keyusage/KeyUsageControllerTest.kt
@@ -6,10 +6,10 @@ import org.cloudfoundry.credhub.helpers.MockMvcFactory
 import org.cloudfoundry.credhub.helpers.credHubAuthHeader
 import org.cloudfoundry.credhub.keyusage.KeyUsageController
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
-import org.junit.After
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType
 import org.springframework.restdocs.ManualRestDocumentation
@@ -28,14 +28,14 @@ class KeyUsageControllerTest {
     lateinit var keyUsageHandler: SpyKeyUsageHandler
 
     companion object {
-        @BeforeClass
+        @BeforeAll
         @JvmStatic
         fun setUpAll() {
             BouncyCastleFipsConfigurer.configure()
         }
     }
 
-    @Before
+    @BeforeEach
     fun setUp() {
         restDocumentation.beforeTest(javaClass, javaClass.simpleName)
         keyUsageHandler = SpyKeyUsageHandler()
@@ -48,7 +48,7 @@ class KeyUsageControllerTest {
         }
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         restDocumentation.afterTest()
     }

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/management/ManagementControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/management/ManagementControllerTest.kt
@@ -5,10 +5,10 @@ import org.cloudfoundry.credhub.helpers.CredHubRestDocs
 import org.cloudfoundry.credhub.helpers.MockMvcFactory
 import org.cloudfoundry.credhub.helpers.credHubAuthHeader
 import org.cloudfoundry.credhub.management.ManagementController
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType
 import org.springframework.restdocs.ManualRestDocumentation
@@ -18,18 +18,18 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.pos
 import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.payload.PayloadDocumentation
 import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 class ManagementControllerTest {
     private val restDocumentation = ManualRestDocumentation()
 
     lateinit var mockMvc: MockMvc
     lateinit var spyManagementService: SpyManagementService
 
-    @Before
+    @BeforeEach
     fun setUp() {
         restDocumentation.beforeTest(javaClass, javaClass.simpleName)
         spyManagementService = SpyManagementService()
@@ -38,7 +38,7 @@ class ManagementControllerTest {
         mockMvc = MockMvcFactory.newSpringRestDocMockMvc(managementController, restDocumentation)
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         restDocumentation.afterTest()
     }

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/permissions/PermissionsV1ControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/permissions/PermissionsV1ControllerTest.kt
@@ -11,9 +11,9 @@ import org.cloudfoundry.credhub.permissions.PermissionsV1Controller
 import org.cloudfoundry.credhub.requests.PermissionEntry
 import org.cloudfoundry.credhub.requests.PermissionsRequest
 import org.cloudfoundry.credhub.views.PermissionsView
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType
 import org.springframework.restdocs.ManualRestDocumentation
@@ -39,7 +39,7 @@ class PermissionsV1ControllerTest {
     lateinit var mockMvc: MockMvc
     lateinit var spyPermissionsV1Handler: SpyPermissionsV1Handler
 
-    @Before
+    @BeforeEach
     fun setUp() {
         restDocumentation.beforeTest(javaClass, javaClass.simpleName)
         spyPermissionsV1Handler = SpyPermissionsV1Handler()
@@ -48,7 +48,7 @@ class PermissionsV1ControllerTest {
         mockMvc = MockMvcFactory.newSpringRestDocMockMvc(permissionsV1Controller, restDocumentation)
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         restDocumentation.afterTest()
     }

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/regenerate/RegenerateControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/regenerate/RegenerateControllerTest.kt
@@ -12,18 +12,18 @@ import org.cloudfoundry.credhub.views.BulkRegenerateResults
 import org.cloudfoundry.credhub.views.CredentialView
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.junit.After
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType
 import org.springframework.restdocs.ManualRestDocumentation
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
 import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.payload.PayloadDocumentation
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -33,7 +33,7 @@ import java.security.Security
 import java.time.Instant
 import java.util.UUID
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 class RegenerateControllerTest {
     private val restDocumentation = ManualRestDocumentation()
 
@@ -44,14 +44,14 @@ class RegenerateControllerTest {
     lateinit var metadata: JsonNode
 
     companion object {
-        @BeforeClass
+        @BeforeAll
         @JvmStatic
         fun setUpAll() {
             BouncyCastleFipsConfigurer.configure()
         }
     }
 
-    @Before
+    @BeforeEach
     fun beforeEach() {
         restDocumentation.beforeTest(javaClass, javaClass.simpleName)
         spyRegenerateHandler = SpyRegenerateHandler()
@@ -65,7 +65,7 @@ class RegenerateControllerTest {
         }
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         restDocumentation.afterTest()
     }

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/versions/VersionControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/versions/VersionControllerTest.kt
@@ -7,10 +7,10 @@ import org.cloudfoundry.credhub.helpers.credHubAuthHeader
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
 import org.cloudfoundry.credhub.utils.VersionProvider
 import org.cloudfoundry.credhub.versions.VersionController
-import org.junit.After
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType
@@ -28,14 +28,14 @@ class VersionControllerTest {
     lateinit var versionProvider: VersionProvider
 
     companion object {
-        @BeforeClass
+        @BeforeAll
         @JvmStatic
         fun setUpAll() {
             BouncyCastleFipsConfigurer.configure()
         }
     }
 
-    @Before
+    @BeforeEach
     fun setUp() {
         restDocumentation.beforeTest(javaClass, javaClass.simpleName)
         versionProvider = Mockito.mock(VersionProvider::class.java)
@@ -49,7 +49,7 @@ class VersionControllerTest {
         }
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         restDocumentation.afterTest()
     }

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v2/permissions/PermissionsV2ControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v2/permissions/PermissionsV2ControllerTest.kt
@@ -10,9 +10,9 @@ import org.cloudfoundry.credhub.helpers.credHubAuthHeader
 import org.cloudfoundry.credhub.permissions.PermissionsV2Controller
 import org.cloudfoundry.credhub.requests.PermissionsV2Request
 import org.cloudfoundry.credhub.views.PermissionsV2View
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType
 import org.springframework.restdocs.ManualRestDocumentation
@@ -41,7 +41,7 @@ class PermissionsV2ControllerTest {
     lateinit var mockMvc: MockMvc
     lateinit var spyPermissionsV2Handler: SpyPermissionsV2Handler
 
-    @Before
+    @BeforeEach
     fun setUp() {
         restDocumentation.beforeTest(javaClass, javaClass.simpleName)
         spyPermissionsV2Handler = SpyPermissionsV2Handler()
@@ -50,7 +50,7 @@ class PermissionsV2ControllerTest {
         mockMvc = MockMvcFactory.newSpringRestDocMockMvc(permissionsV2Controller, restDocumentation)
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         restDocumentation.afterTest()
     }

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/endToEnd/v1/concatenateCas/ConcatenateCasDisabledEndToEndTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/endToEnd/v1/concatenateCas/ConcatenateCasDisabledEndToEndTest.kt
@@ -8,38 +8,36 @@ import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.Timeout
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.context.WebApplicationContext
+import java.util.concurrent.TimeUnit
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @ActiveProfiles(value = ["unit-test"], resolver = DatabaseProfileResolver::class)
 @SpringBootTest(classes = [CredhubTestApp::class])
 @Transactional
 @TestPropertySource(properties = ["certificates.concatenate_cas=false"])
+@Timeout(60, unit = TimeUnit.SECONDS)
 class ConcatenateCasDisabledEndToEndTest {
     @Autowired
     private lateinit var webApplicationContext: WebApplicationContext
 
     private lateinit var mockMvc: MockMvc
 
-    @get:Rule
-    val globalTimeout: Timeout = Timeout.seconds(60)
-
-    @Before
+    @BeforeEach
     fun setUp() {
         BouncyCastleFipsConfigurer.configure()
         mockMvc =

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/endToEnd/v1/concatenateCas/ConcatenateCasEnabledEndToEndTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/endToEnd/v1/concatenateCas/ConcatenateCasEnabledEndToEndTest.kt
@@ -8,38 +8,36 @@ import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.Timeout
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.context.WebApplicationContext
+import java.util.concurrent.TimeUnit
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @ActiveProfiles(value = ["unit-test"], resolver = DatabaseProfileResolver::class)
 @SpringBootTest(classes = [CredhubTestApp::class])
 @Transactional
 @TestPropertySource(properties = ["certificates.concatenate_cas=true"])
+@Timeout(60, unit = TimeUnit.SECONDS)
 class ConcatenateCasEnabledEndToEndTest {
     @Autowired
     private lateinit var webApplicationContext: WebApplicationContext
 
     private lateinit var mockMvc: MockMvc
 
-    @get:Rule
-    val globalTimeout: Timeout = Timeout.seconds(60)
-
-    @Before
+    @BeforeEach
     fun setUp() {
         BouncyCastleFipsConfigurer.configure()
         mockMvc =

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/endToEnd/v1/credentials/CredentialSetEndToEndTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/endToEnd/v1/credentials/CredentialSetEndToEndTest.kt
@@ -12,16 +12,16 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
 import org.json.JSONObject
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
@@ -32,7 +32,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.context.WebApplicationContext
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @ActiveProfiles(value = ["unit-test"], resolver = DatabaseProfileResolver::class)
 @SpringBootTest(classes = [CredhubTestApp::class])
 @Transactional
@@ -52,7 +52,7 @@ class CredentialSetEndToEndTest {
             )
     }
 
-    @Before
+    @BeforeEach
     fun setUp() {
         mockMvc =
             MockMvcBuilders

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/handlers/DefaultKeyUsageHandlerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/handlers/DefaultKeyUsageHandlerTest.kt
@@ -5,8 +5,8 @@ import org.cloudfoundry.credhub.keyusage.DefaultKeyUsageHandler
 import org.cloudfoundry.credhub.services.EncryptionKey
 import org.cloudfoundry.credhub.services.EncryptionKeySet
 import org.cloudfoundry.credhub.services.SpyCredentialVersionDataService
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.mockito.Mockito.mock
 import java.util.UUID
@@ -16,7 +16,7 @@ class DefaultKeyUsageHandlerTest {
     lateinit var keySet: EncryptionKeySet
     lateinit var handler: DefaultKeyUsageHandler
 
-    @Before
+    @BeforeEach
     fun beforeEach() {
         credentialVersionDataService = SpyCredentialVersionDataService()
         keySet = mock(EncryptionKeySet::class.java)

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/handlers/DefaultPermissionsV1HandlerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/handlers/DefaultPermissionsV1HandlerTest.kt
@@ -13,8 +13,8 @@ import org.cloudfoundry.credhub.permissions.DefaultPermissionsV1Handler
 import org.cloudfoundry.credhub.requests.PermissionEntry
 import org.cloudfoundry.credhub.requests.PermissionsRequest
 import org.cloudfoundry.credhub.views.PermissionsView
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class DefaultPermissionsV1HandlerTest {
     private lateinit var credentialVersion: CredentialVersion
@@ -28,7 +28,7 @@ class DefaultPermissionsV1HandlerTest {
         private const val OTHER_ACTOR_NAME = "other-test-actor"
     }
 
-    @Before
+    @BeforeEach
     fun beforeEach() {
         credentialVersion =
             ValueCredentialVersion(

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/handlers/DefaultPermissionsV2HandlerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/handlers/DefaultPermissionsV2HandlerTest.kt
@@ -16,8 +16,8 @@ import org.cloudfoundry.credhub.permissions.DefaultPermissionsV2Handler.Companio
 import org.cloudfoundry.credhub.requests.PermissionEntry
 import org.cloudfoundry.credhub.requests.PermissionsV2Request
 import org.cloudfoundry.credhub.views.PermissionsV2View
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.util.UUID
 
 class DefaultPermissionsV2HandlerTest {
@@ -31,7 +31,7 @@ class DefaultPermissionsV2HandlerTest {
         private const val ACTOR_NAME = "test-actor"
     }
 
-    @Before
+    @BeforeEach
     fun beforeEach() {
         credentialVersion =
             ValueCredentialVersion(

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/handlers/RemoteCredentialsHandlerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/handlers/RemoteCredentialsHandlerTest.kt
@@ -44,12 +44,10 @@ import org.cloudfoundry.credhub.requests.UserSetRequest
 import org.cloudfoundry.credhub.requests.ValueSetRequest
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
 import org.cloudfoundry.credhub.utils.TestConstants
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import tools.jackson.databind.PropertyNamingStrategies
@@ -61,7 +59,6 @@ import java.util.UUID
 private const val CREDENTIAL_NAME = "/test/credential"
 private const val USER = "test-user"
 
-@RunWith(JUnit4::class)
 class RemoteCredentialsHandlerTest {
     private val userContextHolder = mock(UserContextHolder::class.java)!!
     private val objectMapper =
@@ -75,14 +72,14 @@ class RemoteCredentialsHandlerTest {
     private lateinit var versionCreatedAt: String
 
     companion object {
-        @BeforeClass
+        @BeforeAll
         @JvmStatic
         fun setUpAll() {
             BouncyCastleFipsConfigurer.configure()
         }
     }
 
-    @Before
+    @BeforeEach
     fun beforeEach() {
         if (Security.getProvider(BouncyCastleFipsProvider.PROVIDER_NAME) == null) {
             Security.addProvider(BouncyCastleFipsProvider())

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/handlers/RemotePermissionsHandlerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/handlers/RemotePermissionsHandlerTest.kt
@@ -11,11 +11,9 @@ import org.cloudfoundry.credhub.permissions.RemotePermissionsHandler
 import org.cloudfoundry.credhub.remote.RemoteBackendClient
 import org.cloudfoundry.credhub.remote.grpc.PermissionsResponse
 import org.cloudfoundry.credhub.requests.PermissionsV2Request
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import java.util.UUID
@@ -24,13 +22,12 @@ private const val CREDENTIAL_NAME = "/test/credential"
 private const val USER = "test-user"
 private const val ACTOR = "test-actor"
 
-@RunWith(JUnit4::class)
 class RemotePermissionsHandlerTest {
     private lateinit var subject: RemotePermissionsHandler
     private var client = Mockito.mock<RemoteBackendClient>(RemoteBackendClient::class.java)!!
     private val userContextHolder = Mockito.mock<UserContextHolder>(UserContextHolder::class.java)!!
 
-    @Before
+    @BeforeEach
     fun beforeEach() {
         subject = RemotePermissionsHandler(userContextHolder, client)
 

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/certificates/CertificatesGetConcatenateCasIntegrationTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/certificates/CertificatesGetConcatenateCasIntegrationTest.kt
@@ -9,9 +9,9 @@ import org.cloudfoundry.credhub.util.CurrentTimeProvider
 import org.cloudfoundry.credhub.utils.AuthConstants
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver
 import org.cloudfoundry.credhub.utils.TestConstants
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.doReturn
 import org.springframework.beans.factory.annotation.Autowired
@@ -22,7 +22,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -38,7 +38,7 @@ import java.util.UUID
 private const val CREDENTIAL_NAME = "/my-namespace/controllerGetTest/credential-name"
 private const val CREDENTIAL_VALUE = "test value"
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @ActiveProfiles(value = ["unit-test", "unit-test-permissions"], resolver = DatabaseProfileResolver::class)
 @SpringBootTest(classes = [CredhubTestApp::class])
 @Transactional
@@ -60,7 +60,7 @@ class CertificatesGetConcatenateCasIntegrationTest {
 
     private var mockMvc: MockMvc? = null
 
-    @Before
+    @BeforeEach
     fun beforeEach() {
         val fakeTimeSetter = TestHelper.mockOutCurrentTimeProvider(mockCurrentTimeProvider!!)
 

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/certificates/CertificatesGetIntegrationTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/certificates/CertificatesGetIntegrationTest.kt
@@ -9,9 +9,9 @@ import org.cloudfoundry.credhub.util.CurrentTimeProvider
 import org.cloudfoundry.credhub.utils.AuthConstants
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver
 import org.cloudfoundry.credhub.utils.TestConstants
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.doReturn
 import org.springframework.beans.factory.annotation.Autowired
@@ -22,7 +22,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -38,7 +38,7 @@ import java.util.UUID
 private const val CREDENTIAL_NAME = "/my-namespace/controllerGetTest/credential-name"
 private const val CREDENTIAL_VALUE = "test value"
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @ActiveProfiles(value = ["unit-test", "unit-test-permissions"], resolver = DatabaseProfileResolver::class)
 @SpringBootTest(classes = [CredhubTestApp::class])
 @Transactional
@@ -60,7 +60,7 @@ class CertificatesGetIntegrationTest {
 
     private var mockMvc: MockMvc? = null
 
-    @Before
+    @BeforeEach
     fun beforeEach() {
         val fakeTimeSetter = TestHelper.mockOutCurrentTimeProvider(mockCurrentTimeProvider!!)
 

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/certificates/CertificatesPostIntegrationTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/certificates/CertificatesPostIntegrationTest.kt
@@ -12,21 +12,20 @@ import org.cloudfoundry.credhub.utils.CertificateReader
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsEqual.equalTo
-import org.junit.Assert
-import org.junit.Assert.assertNotNull
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.Timeout
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -34,18 +33,17 @@ import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.context.WebApplicationContext
+import java.util.concurrent.TimeUnit
 
 private const val CA_NAME = "/test-ca"
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @ActiveProfiles(value = ["unit-test", "unit-test-permissions"], resolver = DatabaseProfileResolver::class)
 @SpringBootTest(classes = [CredhubTestApp::class])
 @Transactional
 @TestPropertySource(properties = ["certificates.concatenate_cas=false"])
+@Timeout(60, unit = TimeUnit.SECONDS)
 class CertificatesPostIntegrationTest {
-    @get:Rule
-    val globalTimeout: Timeout = Timeout.seconds(60)
-
     @Autowired
     private val webApplicationContext: WebApplicationContext? = null
 
@@ -54,14 +52,14 @@ class CertificatesPostIntegrationTest {
     private var caCredentialUuid: String = ""
 
     companion object {
-        @BeforeClass
+        @BeforeAll
         @JvmStatic
         fun setUpAll() {
             BouncyCastleFipsConfigurer.configure()
         }
     }
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
     fun beforeEach() {
         mockMvc =
@@ -139,7 +137,7 @@ class CertificatesPostIntegrationTest {
             JsonPath
                 .parse(regenerateCertificateResponse)
                 .read<Boolean>("$.transitional")
-        Assert.assertTrue(caCertificateRegeneratedIsTransitional)
+        assertTrue(caCertificateRegeneratedIsTransitional)
 
         val certCredentialUuid = getCertificateId(mockMvc, certificateName)
         val regenerateLeafRequest =
@@ -161,6 +159,6 @@ class CertificatesPostIntegrationTest {
         assertThat<String>(leafCA, equalTo<String>(caCertificate!!))
         val leafCert = JsonPath.parse(response).read<String>("$.value.certificate")
         val reader = CertificateReader(leafCert)
-        Assert.assertTrue(reader.isSignedByCa(caCertificate))
+        assertTrue(reader.isSignedByCa(caCertificate))
     }
 }

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsGetConcatenateCasIntegrationTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsGetConcatenateCasIntegrationTest.kt
@@ -10,9 +10,9 @@ import org.cloudfoundry.credhub.util.CurrentTimeProvider
 import org.cloudfoundry.credhub.utils.AuthConstants
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver
 import org.cloudfoundry.credhub.utils.TestConstants
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.doReturn
 import org.springframework.beans.factory.annotation.Autowired
@@ -23,7 +23,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -40,7 +40,7 @@ import java.util.UUID
 private const val CREDENTIAL_NAME = "/my-namespace/controllerGetTest/credential-name"
 private const val CREDENTIAL_VALUE = "test value"
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @ActiveProfiles(value = ["unit-test", "unit-test-permissions"], resolver = DatabaseProfileResolver::class)
 @SpringBootTest(classes = [CredhubTestApp::class])
 @Transactional
@@ -62,7 +62,7 @@ class CredentialsGetConcatenateCasIntegrationTest {
 
     private var mockMvc: MockMvc? = null
 
-    @Before
+    @BeforeEach
     fun beforeEach() {
         val fakeTimeSetter = TestHelper.mockOutCurrentTimeProvider(mockCurrentTimeProvider!!)
 

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsPostIntegrationTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/credentials/CredentialsPostIntegrationTest.kt
@@ -9,10 +9,10 @@ import org.cloudfoundry.credhub.utils.AuthConstants
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver
 import org.cloudfoundry.credhub.utils.TestConstants
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -22,7 +22,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
@@ -32,7 +32,7 @@ import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.context.WebApplicationContext
 import java.time.Instant
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @ActiveProfiles(value = ["unit-test", "unit-test-permissions"], resolver = DatabaseProfileResolver::class)
 @SpringBootTest(classes = [CredhubTestApp::class])
 @Transactional
@@ -52,14 +52,14 @@ class CredentialsPostIntegrationTest {
     private var mockMvc: MockMvc? = null
 
     companion object {
-        @BeforeClass
+        @BeforeAll
         @JvmStatic
         fun setUpAll() {
             BouncyCastleFipsConfigurer.configure()
         }
     }
 
-    @Before
+    @BeforeEach
     fun beforeEach() {
         val fakeTimeSetter = TestHelper.mockOutCurrentTimeProvider(mockCurrentTimeProvider!!)
 

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/regneration/RegenerateEndpointConcatenateCasIntegrationTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/integration/v1/regneration/RegenerateEndpointConcatenateCasIntegrationTest.kt
@@ -9,14 +9,13 @@ import org.cloudfoundry.credhub.utils.CertificateReader
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsEqual
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.Timeout
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.ApplicationContext
@@ -26,7 +25,7 @@ import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
@@ -36,14 +35,16 @@ import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.context.WebApplicationContext
+import java.util.concurrent.TimeUnit
 
 private const val API_V1_REGENERATE_ENDPOINT = "/api/v1/regenerate"
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @ActiveProfiles(value = ["unit-test", "unit-test-permissions"], resolver = DatabaseProfileResolver::class)
 @SpringBootTest(classes = [CredhubTestApp::class])
 @Transactional
 @TestPropertySource(properties = ["certificates.concatenate_cas=true"])
+@Timeout(60, unit = TimeUnit.SECONDS)
 class RegenerateEndpointConcatenateCasIntegrationTest {
     @Autowired
     private val webApplicationContext: WebApplicationContext? = null
@@ -56,18 +57,15 @@ class RegenerateEndpointConcatenateCasIntegrationTest {
 
     private lateinit var mockMvc: MockMvc
 
-    @get:Rule
-    val globalTimeout: Timeout = Timeout.seconds(60)
-
     companion object {
-        @BeforeClass
+        @BeforeAll
         @JvmStatic
         fun setUpAll() {
             BouncyCastleFipsConfigurer.configure()
         }
     }
 
-    @Before
+    @BeforeEach
     fun beforeEach() {
         mockMvc =
             MockMvcBuilders

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,10 @@ subprojects {
             implementation("com.h2database:h2")
             implementation("com.google.guava:guava:${guavaVersion}")
             testImplementation("org.mockito:mockito-core")
+            testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+        }
+        tasks.withType(Test) {
+            useJUnitPlatform()
         }
     }
 }

--- a/components/audit/build.gradle
+++ b/components/audit/build.gradle
@@ -18,7 +18,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation('org.springframework.boot:spring-boot-starter-security')
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("junit:junit")
 
     implementation('tools.jackson.module:jackson-module-kotlin')
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/components/audit/src/test/kotlin/org/cloudfoundry/credhub/audit/CEFAuditRecordTest.kt
+++ b/components/audit/src/test/kotlin/org/cloudfoundry/credhub/audit/CEFAuditRecordTest.kt
@@ -3,8 +3,8 @@ package org.cloudfoundry.credhub.audit
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.`is`
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.springframework.mock.web.MockHttpServletRequest
 import java.nio.charset.StandardCharsets.UTF_8
 
@@ -12,7 +12,7 @@ class CEFAuditRecordTest {
     private var auditRecord: CEFAuditRecord? = null
     private var httpRequest: MockHttpServletRequest? = null
 
-    @Before
+    @BeforeEach
     fun setUp() {
         this.auditRecord = CEFAuditRecord()
         this.httpRequest = MockHttpServletRequest()

--- a/components/audit/src/test/kotlin/org/cloudfoundry/credhub/interceptors/AuditInterceptorTest.kt
+++ b/components/audit/src/test/kotlin/org/cloudfoundry/credhub/interceptors/AuditInterceptorTest.kt
@@ -12,10 +12,8 @@ import org.cloudfoundry.credhub.utils.VersionProvider
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.`is`
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
@@ -26,7 +24,6 @@ import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.security.core.Authentication
 import java.util.UUID
 
-@RunWith(JUnit4::class)
 class AuditInterceptorTest {
     private var subject: AuditInterceptor? = null
     private var userContextFactory: UserContextFactory? = null
@@ -36,7 +33,7 @@ class AuditInterceptorTest {
     private var auditRecord: CEFAuditRecord? = null
     private var versionProvider: VersionProvider? = null
 
-    @Before
+    @BeforeEach
     fun setup() {
         versionProvider = mock(VersionProvider::class.java)
         `when`(versionProvider!!.currentVersion()).thenReturn("x.x.x")

--- a/components/auth/build.gradle
+++ b/components/auth/build.gradle
@@ -25,7 +25,6 @@ dependencies {
 
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("junit:junit")
 
     implementation('tools.jackson.module:jackson-module-kotlin')
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/components/auth/src/test/java/org/cloudfoundry/credhub/auth/OAuth2AuthenticationExceptionHandlerTest.java
+++ b/components/auth/src/test/java/org/cloudfoundry/credhub/auth/OAuth2AuthenticationExceptionHandlerTest.java
@@ -6,8 +6,8 @@ import org.springframework.security.authentication.InsufficientAuthenticationExc
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -17,7 +17,7 @@ public class OAuth2AuthenticationExceptionHandlerTest {
     private MockHttpServletRequest request;
     private MockHttpServletResponse response;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         exceptionHandler = new OAuth2AuthenticationExceptionHandler();
         request = new MockHttpServletRequest();

--- a/components/auth/src/test/kotlin/org/cloudfoundry/credhub/auth/DefaultOAuth2IssuerServiceTest.kt
+++ b/components/auth/src/test/kotlin/org/cloudfoundry/credhub/auth/DefaultOAuth2IssuerServiceTest.kt
@@ -4,10 +4,8 @@ import org.cloudfoundry.credhub.RestTemplateFactory
 import org.cloudfoundry.credhub.config.OAuthProperties
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsEqual.equalTo
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.springframework.http.HttpStatus
@@ -22,13 +20,12 @@ import java.security.NoSuchAlgorithmException
 import java.security.cert.CertificateException
 import java.util.HashMap
 
-@RunWith(JUnit4::class)
 class DefaultOAuth2IssuerServiceTest {
     private var subject: DefaultOAuth2IssuerService? = null
 
     private var restTemplate: RestTemplate? = null
 
-    @Before
+    @BeforeEach
     @Throws(
         URISyntaxException::class,
         CertificateException::class,

--- a/components/auth/src/test/kotlin/org/cloudfoundry/credhub/auth/OAuth2ExtraValidationFilterTest.kt
+++ b/components/auth/src/test/kotlin/org/cloudfoundry/credhub/auth/OAuth2ExtraValidationFilterTest.kt
@@ -11,9 +11,9 @@ import org.cloudfoundry.credhub.utils.AuthConstants.Companion.VALID_ISSUER_JWT
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsEqual.equalTo
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -26,7 +26,7 @@ import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfig
 import org.springframework.security.web.FilterChainProxy
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -37,7 +37,7 @@ import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @ActiveProfiles(value = ["unit-test"], resolver = DatabaseProfileResolver::class)
 @SpringBootTest(classes = [CredhubTestApp::class])
 @Transactional
@@ -54,7 +54,7 @@ class OAuth2ExtraValidationFilterTest {
     @Autowired
     private var jwtDecoder: NimbusJwtDecoder? = null
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
     fun beforeEach() {
         spyController = SpyController()

--- a/components/auth/src/test/kotlin/org/cloudfoundry/credhub/auth/UserContextFactoryTest.kt
+++ b/components/auth/src/test/kotlin/org/cloudfoundry/credhub/auth/UserContextFactoryTest.kt
@@ -7,9 +7,9 @@ import org.cloudfoundry.credhub.utils.DatabaseProfileResolver
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsEqual.equalTo
 import org.hamcrest.core.StringContains.containsString
-import org.junit.Test
 import org.junit.jupiter.api.Assertions
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
@@ -19,13 +19,13 @@ import org.springframework.security.oauth2.jwt.JwtClaimNames
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.security.cert.X509Certificate
 import java.time.Instant
 import java.util.Date
 import javax.security.auth.x500.X500Principal
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @ActiveProfiles(profiles = ["unit-test"], resolver = DatabaseProfileResolver::class)
 @SpringBootTest(classes = [CredhubTestApp::class])
 class UserContextFactoryTest {

--- a/components/auth/src/test/kotlin/org/cloudfoundry/credhub/interceptors/UserContextInterceptorTest.kt
+++ b/components/auth/src/test/kotlin/org/cloudfoundry/credhub/interceptors/UserContextInterceptorTest.kt
@@ -1,16 +1,14 @@
 package org.cloudfoundry.credhub.interceptors
 
 import jakarta.servlet.http.HttpServletRequest
-import junit.framework.TestCase.assertFalse
 import org.cloudfoundry.credhub.auth.UserContext
 import org.cloudfoundry.credhub.auth.UserContextFactory
 import org.cloudfoundry.credhub.auth.UserContextHolder
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
@@ -18,7 +16,6 @@ import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.security.core.Authentication
 import java.security.Principal
 
-@RunWith(JUnit4::class)
 class UserContextInterceptorTest {
     private var subject: UserContextInterceptor? = null
     private var userContext: UserContext? = null
@@ -27,7 +24,7 @@ class UserContextInterceptorTest {
     private var request: HttpServletRequest? = null
     private var response: MockHttpServletResponse? = null
 
-    @Before
+    @BeforeEach
     fun setup() {
         userContextFactory = mock(UserContextFactory::class.java)
         userContext = mock(UserContext::class.java)

--- a/components/encryption/build.gradle
+++ b/components/encryption/build.gradle
@@ -45,7 +45,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
-    testImplementation("junit:junit")
 
     implementation('tools.jackson.module:jackson-module-kotlin')
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/components/encryption/src/test/java/org/cloudfoundry/credhub/config/BouncyCastleProviderConfigurationTest.java
+++ b/components/encryption/src/test/java/org/cloudfoundry/credhub/config/BouncyCastleProviderConfigurationTest.java
@@ -5,22 +5,22 @@ import java.security.PrivateKey;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers.sha256WithRSAEncryption;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = BouncyCastleProviderConfiguration.class)
 public class BouncyCastleProviderConfigurationTest {
 
@@ -29,12 +29,12 @@ public class BouncyCastleProviderConfigurationTest {
 
   private KeyPairGenerator generator;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() {
     BouncyCastleFipsConfigurer.configure();
   }
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     generator = KeyPairGenerator
       .getInstance("RSA", BouncyCastleFipsProvider.PROVIDER_NAME);

--- a/components/encryption/src/test/java/org/cloudfoundry/credhub/config/EncryptionKeyProviderTest.java
+++ b/components/encryption/src/test/java/org/cloudfoundry/credhub/config/EncryptionKeyProviderTest.java
@@ -1,15 +1,12 @@
 package org.cloudfoundry.credhub.config;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-@RunWith(JUnit4.class)
 public class EncryptionKeyProviderTest {
 
   @Test

--- a/components/encryption/src/test/java/org/cloudfoundry/credhub/config/EncryptionKeysConfigurationTest.java
+++ b/components/encryption/src/test/java/org/cloudfoundry/credhub/config/EncryptionKeysConfigurationTest.java
@@ -5,18 +5,18 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 @Transactional

--- a/components/encryption/src/test/java/org/cloudfoundry/credhub/credential/CryptSaltFactoryTest.java
+++ b/components/encryption/src/test/java/org/cloudfoundry/credhub/credential/CryptSaltFactoryTest.java
@@ -1,15 +1,12 @@
 package org.cloudfoundry.credhub.credential;
 
 import org.cloudfoundry.credhub.CryptSaltFactory;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-@RunWith(JUnit4.class)
 public class CryptSaltFactoryTest {
   @Test
   public void generateSalt_returnsCorrectlyFormattedSalt() {

--- a/components/encryption/src/test/java/org/cloudfoundry/credhub/data/EncryptedValueDataServiceTest.java
+++ b/components/encryption/src/test/java/org/cloudfoundry/credhub/data/EncryptedValueDataServiceTest.java
@@ -9,16 +9,16 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.domain.Encryptor;
 import org.cloudfoundry.credhub.entities.EncryptedValue;
 import org.cloudfoundry.credhub.repositories.EncryptedValueRepository;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -28,7 +28,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 public class EncryptedValueDataServiceTest {
@@ -41,7 +41,7 @@ public class EncryptedValueDataServiceTest {
 
   private EncryptedValueDataService subject;
 
-  @Before
+  @BeforeEach
   public void beforeEach() {
     subject = new EncryptedValueDataService(encryptedValueRepository, encryptor);
   }

--- a/components/encryption/src/test/java/org/cloudfoundry/credhub/data/EncryptionKeyCanaryDataServiceTest.java
+++ b/components/encryption/src/test/java/org/cloudfoundry/credhub/data/EncryptionKeyCanaryDataServiceTest.java
@@ -9,15 +9,15 @@ import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabas
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.entities.EncryptionKeyCanary;
 import org.cloudfoundry.credhub.repositories.EncryptionKeyCanaryRepository;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -25,9 +25,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 @SpringBootTest(classes = CredhubTestApp.class)
@@ -38,7 +38,7 @@ public class EncryptionKeyCanaryDataServiceTest {
 
   private EncryptionKeyCanaryDataService subject;
 
-  @Before
+  @BeforeEach
   public void beforeEach() {
     encryptionKeyCanaryRepository.deleteAllInBatch();
     subject = new EncryptionKeyCanaryDataService(encryptionKeyCanaryRepository);

--- a/components/encryption/src/test/java/org/cloudfoundry/credhub/db/migration/EarlyCredentialMigrationTest.java
+++ b/components/encryption/src/test/java/org/cloudfoundry/credhub/db/migration/EarlyCredentialMigrationTest.java
@@ -10,7 +10,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import org.cloudfoundry.credhub.CredhubTestApp;
 import org.cloudfoundry.credhub.entities.EncryptionKeyCanary;
@@ -18,14 +18,14 @@ import org.cloudfoundry.credhub.repositories.EncryptionKeyCanaryRepository;
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.MigrationVersion;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ActiveProfiles(value = "unit-test", resolver = DatabaseProfileResolver.class)
 @SpringBootTest(classes = CredhubTestApp.class)
 public class EarlyCredentialMigrationTest {
@@ -44,7 +44,7 @@ public class EarlyCredentialMigrationTest {
     private long id = 0;
     private List<EncryptionKeyCanary> canaries;
 
-    @Before
+    @BeforeEach
     public void beforeEach() {
         canaries = encryptionKeyCanaryRepository.findAll();
 
@@ -60,7 +60,7 @@ public class EarlyCredentialMigrationTest {
     flywayV4.migrate();
   }
 
-  @After
+  @AfterEach
   public void afterEach() {
     flyway.clean();
     flyway.migrate();

--- a/components/encryption/src/test/java/org/cloudfoundry/credhub/domain/EncryptorTest.java
+++ b/components/encryption/src/test/java/org/cloudfoundry/credhub/domain/EncryptorTest.java
@@ -4,31 +4,25 @@ import java.util.UUID;
 
 import org.cloudfoundry.credhub.entities.EncryptedValue;
 import org.cloudfoundry.credhub.services.RetryingEncryptionService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(JUnit4.class)
 public class EncryptorTest {
 
   private Encryptor subject;
-
-  private byte[] encryptedValue;
-
-  private byte[] nonce;
   private UUID oldUuid;
   private UUID newUuid;
   private RetryingEncryptionService encryptionService;
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     oldUuid = UUID.randomUUID();
     newUuid = UUID.randomUUID();
@@ -56,11 +50,11 @@ public class EncryptorTest {
     assertThat(result, equalTo(encrypted));
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void encrypt_wrapsExceptions() throws Exception {
     when(encryptionService.encrypt(any())).thenThrow(new IllegalArgumentException());
 
-    subject.encrypt("some value");
+    assertThrows(RuntimeException.class, () -> subject.encrypt("some value"));
   }
 
   @Test
@@ -72,12 +66,14 @@ public class EncryptorTest {
     assertThat(result, equalTo(expected));
   }
 
-  @Test(expected = RuntimeException.class)
-  public void decrypt_failsToEncryptWhenGivenWrongKeyUuid() {
-    final EncryptedValue encryption = subject.encrypt("the expected clear text");
-    encryptedValue = encryption.getEncryptedValue();
-    nonce = encryption.getNonce();
+  @Test
+  public void decrypt_failsToEncryptWhenGivenWrongKeyUuid() throws Exception {
+    final EncryptedValue knownKeyValue = new EncryptedValue(newUuid, new byte[]{}, new byte[]{});
+    final EncryptedValue unknownKeyValue = new EncryptedValue(oldUuid, new byte[]{}, new byte[]{});
 
-    subject.decrypt(new EncryptedValue(oldUuid, encryptedValue, nonce));
+    when(encryptionService.decrypt(knownKeyValue)).thenReturn("decrypted");
+    when(encryptionService.decrypt(unknownKeyValue)).thenThrow(new RuntimeException("key not found: " + oldUuid));
+
+    assertThrows(RuntimeException.class, () -> subject.decrypt(new EncryptedValue(oldUuid, new byte[]{}, new byte[]{})));
   }
 }

--- a/components/encryption/src/test/java/org/cloudfoundry/credhub/entities/EncryptionKeyCanaryTest.java
+++ b/components/encryption/src/test/java/org/cloudfoundry/credhub/entities/EncryptionKeyCanaryTest.java
@@ -3,10 +3,8 @@ package org.cloudfoundry.credhub.entities;
 import java.util.UUID;
 
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -14,12 +12,11 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-@RunWith(JUnit4.class)
 public class EncryptionKeyCanaryTest {
 
   private EncryptionKeyCanary subject;
 
-  @Before
+  @BeforeEach
   public void beforeEach() {
     subject = new EncryptionKeyCanary();
   }

--- a/components/encryption/src/test/java/org/cloudfoundry/credhub/services/EncryptionKeyCanaryMapperTest.java
+++ b/components/encryption/src/test/java/org/cloudfoundry/credhub/services/EncryptionKeyCanaryMapperTest.java
@@ -21,10 +21,8 @@ import org.cloudfoundry.credhub.data.EncryptionKeyCanaryDataService;
 import org.cloudfoundry.credhub.entities.EncryptedValue;
 import org.cloudfoundry.credhub.entities.EncryptionKeyCanary;
 import org.cloudfoundry.credhub.util.TimedRetry;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import static com.google.common.collect.Lists.newArrayList;
@@ -46,7 +44,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(JUnit4.class)
 public class EncryptionKeyCanaryMapperTest {
   private EncryptionKeyCanaryMapper subject;
   private EncryptionKeyCanaryDataService encryptionKeyCanaryDataService;
@@ -75,7 +72,7 @@ public class EncryptionKeyCanaryMapperTest {
   private EncryptionKeysConfiguration encryptionKeysConfiguration;
   private EncryptionProviderFactory providerFactory;
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     encryptionKeyCanaryDataService = mock(EncryptionKeyCanaryDataService.class);
     encryptionService = mock(InternalEncryptionService.class);

--- a/components/encryption/src/test/java/org/cloudfoundry/credhub/services/EncryptionKeyRotatorTest.java
+++ b/components/encryption/src/test/java/org/cloudfoundry/credhub/services/EncryptionKeyRotatorTest.java
@@ -9,10 +9,8 @@ import org.springframework.data.domain.SliceImpl;
 
 import org.cloudfoundry.credhub.data.EncryptedValueDataService;
 import org.cloudfoundry.credhub.entities.EncryptedValue;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Arrays.asList;
@@ -20,7 +18,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(JUnit4.class)
 public class EncryptionKeyRotatorTest {
 
   private EncryptedValueDataService encryptedValueDataService;
@@ -33,7 +30,7 @@ public class EncryptionKeyRotatorTest {
   private List<UUID> inactiveCanaries;
   private EncryptionKeySet keySet;
 
-  @Before
+  @BeforeEach
   public void beforeEach() {
     oldUuid = UUID.randomUUID();
     final UUID activeUuid = UUID.randomUUID();

--- a/components/encryption/src/test/java/org/cloudfoundry/credhub/services/EncryptionProviderFactoryTest.java
+++ b/components/encryption/src/test/java/org/cloudfoundry/credhub/services/EncryptionProviderFactoryTest.java
@@ -4,10 +4,8 @@ import org.cloudfoundry.credhub.config.EncryptionKeyProvider;
 import org.cloudfoundry.credhub.config.EncryptionKeysConfiguration;
 import org.cloudfoundry.credhub.config.ProviderType;
 import org.cloudfoundry.credhub.util.TimedRetry;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -17,12 +15,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(JUnit4.class)
 public class EncryptionProviderFactoryTest {
   @Mock
   private EncryptionKeyProvider provider;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     MockitoAnnotations.openMocks(this);
   }

--- a/components/encryption/src/test/java/org/cloudfoundry/credhub/services/ExternalKeyProxyTest.java
+++ b/components/encryption/src/test/java/org/cloudfoundry/credhub/services/ExternalKeyProxyTest.java
@@ -6,31 +6,28 @@ import javax.crypto.IllegalBlockSizeException;
 import org.cloudfoundry.credhub.config.EncryptionKeyMetadata;
 import org.cloudfoundry.credhub.entities.EncryptionKeyCanary;
 import org.cloudfoundry.credhub.exceptions.IncorrectKeyException;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(JUnit4.class)
 public class ExternalKeyProxyTest {
   private ExternalKeyProxy subject;
   private EncryptionProvider encryptionProvider;
   private EncryptionKeyMetadata encryptionKeyMetadata;
   private EncryptionKeyCanary encryptionKeyCanary;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     encryptionProvider = mock(EncryptionProvider.class);
     encryptionKeyMetadata = mock(EncryptionKeyMetadata.class);

--- a/components/encryption/src/test/java/org/cloudfoundry/credhub/services/LunaEncryptionServiceTest.java
+++ b/components/encryption/src/test/java/org/cloudfoundry/credhub/services/LunaEncryptionServiceTest.java
@@ -6,10 +6,8 @@ import javax.crypto.SecretKey;
 
 import org.cloudfoundry.credhub.config.EncryptionKeyMetadata;
 import org.cloudfoundry.credhub.util.TimedRetry;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -20,7 +18,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(JUnit4.class)
 public class LunaEncryptionServiceTest {
 
   private LunaEncryptionService subject;
@@ -28,7 +25,7 @@ public class LunaEncryptionServiceTest {
   private SecretKey aesKey;
   private TimedRetry timedRetry;
 
-  @Before
+  @BeforeEach
   @SuppressWarnings("Duplicates")
   public void setUp() throws Exception {
     connection = mock(LunaConnection.class);

--- a/components/encryption/src/test/java/org/cloudfoundry/credhub/services/LunaKeyProxyTest.java
+++ b/components/encryption/src/test/java/org/cloudfoundry/credhub/services/LunaKeyProxyTest.java
@@ -8,10 +8,8 @@ import org.cloudfoundry.credhub.config.EncryptionKeyMetadata;
 import org.cloudfoundry.credhub.entities.EncryptedValue;
 import org.cloudfoundry.credhub.entities.EncryptionKeyCanary;
 import org.cloudfoundry.credhub.utils.TestPasswordKeyProxyFactory;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.fail;
 import static org.cloudfoundry.credhub.services.EncryptionKeyCanaryMapper.CANARY_VALUE;
@@ -20,14 +18,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Mockito.mock;
 
-@RunWith(JUnit4.class)
 public class LunaKeyProxyTest {
   private LunaKeyProxy subject;
   private Key encryptionKey;
   private EncryptionKeyCanary canary;
   private EncryptionKeyCanary deprecatedCanary;
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     final PasswordEncryptionService encryptionService = new PasswordEncryptionService(
       new TestPasswordKeyProxyFactory()

--- a/components/encryption/src/test/java/org/cloudfoundry/credhub/services/PasswordBasedKeyProxyTest.java
+++ b/components/encryption/src/test/java/org/cloudfoundry/credhub/services/PasswordBasedKeyProxyTest.java
@@ -11,10 +11,8 @@ import org.cloudfoundry.credhub.constants.EncryptionConstants;
 import org.cloudfoundry.credhub.entities.EncryptedValue;
 import org.cloudfoundry.credhub.entities.EncryptionKeyCanary;
 import org.cloudfoundry.credhub.utils.TestPasswordKeyProxyFactory;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
@@ -24,20 +22,19 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(JUnit4.class)
 public class PasswordBasedKeyProxyTest {
   private PasswordBasedKeyProxy subject;
   private String password;
 
   private PasswordEncryptionService encryptionService;
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws Exception {
     password = "abcdefghijklmnopqrst";
     encryptionService = new PasswordEncryptionService(new TestPasswordKeyProxyFactory());

--- a/components/encryption/src/test/java/org/cloudfoundry/credhub/services/PasswordEncryptionServiceTest.java
+++ b/components/encryption/src/test/java/org/cloudfoundry/credhub/services/PasswordEncryptionServiceTest.java
@@ -2,14 +2,11 @@ package org.cloudfoundry.credhub.services;
 
 import org.cloudfoundry.credhub.config.EncryptionKeyMetadata;
 import org.cloudfoundry.credhub.utils.TestPasswordKeyProxyFactory;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@RunWith(JUnit4.class)
 public class PasswordEncryptionServiceTest {
   @Test
   public void createsPasswordBasedKeyProxy() throws Exception {

--- a/components/encryption/src/test/java/org/cloudfoundry/credhub/services/RetryingEncryptionServiceTest.java
+++ b/components/encryption/src/test/java/org/cloudfoundry/credhub/services/RetryingEncryptionServiceTest.java
@@ -8,17 +8,16 @@ import javax.crypto.IllegalBlockSizeException;
 
 import org.cloudfoundry.credhub.entities.EncryptedValue;
 import org.cloudfoundry.credhub.exceptions.KeyNotFoundException;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
@@ -30,7 +29,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(JUnit4.class)
 public class RetryingEncryptionServiceTest {
 
   private RetryingEncryptionService subject;
@@ -45,7 +43,7 @@ public class RetryingEncryptionServiceTest {
   private EncryptionKey firstActiveKey;
   private EncryptionKey secondActiveKey;
 
-  @Before
+  @BeforeEach
   public void beforeEach() {
     keySet = mock(EncryptionKeySet.class);
     encryptionService = mock(LunaEncryptionService.class);
@@ -390,12 +388,13 @@ public class RetryingEncryptionServiceTest {
     verify(keySet, times(1)).reload();
   }
 
-  @Test(expected = KeyNotFoundException.class)
+  @Test
   public void decrypt_whenTheEncryptionKeyCannotBeFound_throwsAnException() throws Exception {
     final UUID fakeUuid = UUID.randomUUID();
     reset(encryptionService);
     when(keySet.get(fakeUuid)).thenReturn(null);
-    subject.decrypt(new EncryptedValue(fakeUuid, "something we cant read".getBytes(UTF_8), "nonce".getBytes(UTF_8)));
+    assertThrows(KeyNotFoundException.class, () ->
+      subject.decrypt(new EncryptedValue(fakeUuid, "something we cant read".getBytes(UTF_8), "nonce".getBytes(UTF_8))));
   }
 
   @Test

--- a/components/encryption/src/test/kotlin/org/cloudfoundry/credhub/utils/BouncyCastleFipsConfigurerTest.kt
+++ b/components/encryption/src/test/kotlin/org/cloudfoundry/credhub/utils/BouncyCastleFipsConfigurerTest.kt
@@ -2,18 +2,18 @@ package org.cloudfoundry.credhub.utils
 
 import org.bouncycastle.crypto.CryptoServicesRegistrar
 import org.cloudfoundry.credhub.config.BouncyCastleProviderConfiguration
-import org.junit.Assert.assertTrue
-import org.junit.BeforeClass
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.test.context.ContextConfiguration
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [BouncyCastleProviderConfiguration::class])
 internal class BouncyCastleFipsConfigurerTest {
     companion object {
-        @BeforeClass
+        @BeforeAll
         @JvmStatic
         fun setUp() {
             BouncyCastleFipsConfigurer.configure()

--- a/components/errors/build.gradle
+++ b/components/errors/build.gradle
@@ -13,7 +13,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
     implementation('org.springframework.boot:spring-boot-starter-validation')
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("junit:junit")
 
     implementation('tools.jackson.module:jackson-module-kotlin')
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/components/errors/src/test/kotlin/org/cloudfoundry/credhub/exceptions/ParameterizedValidationExceptionTest.kt
+++ b/components/errors/src/test/kotlin/org/cloudfoundry/credhub/exceptions/ParameterizedValidationExceptionTest.kt
@@ -4,11 +4,8 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.array
 import org.hamcrest.core.IsEqual.equalTo
 import org.hamcrest.core.IsInstanceOf.instanceOf
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 
-@RunWith(JUnit4::class)
 class ParameterizedValidationExceptionTest {
     @Test
     fun exception_extendValidationException() {

--- a/components/errors/src/test/kotlin/org/cloudfoundry/credhub/generate/ExceptionHandlersTest.kt
+++ b/components/errors/src/test/kotlin/org/cloudfoundry/credhub/generate/ExceptionHandlersTest.kt
@@ -2,8 +2,8 @@ package org.cloudfoundry.credhub.generate
 
 import org.cloudfoundry.credhub.exceptions.EntryNotFoundException
 import org.cloudfoundry.credhub.views.ResponseError
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 
 class ExceptionHandlersTest {
     @Test

--- a/components/generate/build.gradle
+++ b/components/generate/build.gradle
@@ -23,7 +23,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation('org.springframework.boot:spring-boot-starter-validation')
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("junit:junit")
 
     implementation('tools.jackson.module:jackson-module-kotlin')
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/components/generate/src/test/kotlin/org/cloudfoundry/credhub/requests/BulkRegenerateRequestTest.kt
+++ b/components/generate/src/test/kotlin/org/cloudfoundry/credhub/requests/BulkRegenerateRequestTest.kt
@@ -4,11 +4,8 @@ import org.cloudfoundry.credhub.ErrorMessages
 import org.cloudfoundry.credhub.helpers.JsonTestHelper
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 
-@RunWith(JUnit4::class)
 class BulkRegenerateRequestTest {
     @Test
     fun whenSignedByValueIsMissing__isInvalid() {

--- a/components/generate/src/test/kotlin/org/cloudfoundry/credhub/requests/RegenerateRequestTest.kt
+++ b/components/generate/src/test/kotlin/org/cloudfoundry/credhub/requests/RegenerateRequestTest.kt
@@ -6,11 +6,8 @@ import org.cloudfoundry.credhub.helpers.JsonTestHelper.Companion.deserializeAndV
 import org.cloudfoundry.credhub.helpers.JsonTestHelper.Companion.hasViolationWithMessage
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 
-@RunWith(JUnit4::class)
 class RegenerateRequestTest {
     @Test
     fun whenNameIsMissing__isInvalid() {

--- a/components/management/build.gradle
+++ b/components/management/build.gradle
@@ -14,7 +14,6 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("junit:junit")
     testImplementation project(path: ":components:test-support", configuration: "testOutput")
     testImplementation("org.springframework.boot:spring-boot-starter-flyway")
     testImplementation("org.flywaydb:flyway-database-postgresql")

--- a/components/management/src/test/kotlin/org/cloudfoundry/credhub/interceptors/ManagementInterceptorTest.kt
+++ b/components/management/src/test/kotlin/org/cloudfoundry/credhub/interceptors/ManagementInterceptorTest.kt
@@ -6,20 +6,19 @@ import org.cloudfoundry.credhub.ManagementRegistry
 import org.cloudfoundry.credhub.exceptions.InvalidRemoteAddressException
 import org.cloudfoundry.credhub.exceptions.ReadOnlyException
 import org.cloudfoundry.credhub.utils.DatabaseProfileResolver
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.core.Is.`is`
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @ActiveProfiles(value = ["unit-test"], resolver = DatabaseProfileResolver::class)
 @SpringBootTest(classes = [CredhubTestApp::class])
 class ManagementInterceptorTest {
@@ -30,7 +29,7 @@ class ManagementInterceptorTest {
     @Autowired
     private val managementRegistry: ManagementRegistry? = null
 
-    @Before
+    @BeforeEach
     fun setup() {
         subject = ManagementInterceptor(managementRegistry!!)
         request = MockHttpServletRequest()
@@ -39,18 +38,19 @@ class ManagementInterceptorTest {
         managementRegistry.readOnlyMode = false
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         managementRegistry!!.readOnlyMode = false
     }
 
-    @Test(expected = InvalidRemoteAddressException::class)
+    @Test
     fun preHandle_throwsAnExceptionWhenRemoteAddressDoesNotMatchLocalAddress() {
         request!!.remoteAddr = "10.0.0.1"
         request!!.localAddr = "127.0.0.1"
         request!!.requestURI = "/management"
-        subject!!.preHandle(request!!, response!!, Any())
-        assertThat(response!!.status, `is`(401))
+        assertThrows<InvalidRemoteAddressException> {
+            subject!!.preHandle(request!!, response!!, Any())
+        }
     }
 
     @Test
@@ -61,13 +61,14 @@ class ManagementInterceptorTest {
         subject!!.preHandle(request!!, response!!, Any())
     }
 
-    @Test(expected = ReadOnlyException::class)
+    @Test
     fun preHandle_throwsAnExceptionWhenTheRequestMethodIsNotGetInReadOnlyMode() {
         managementRegistry!!.readOnlyMode = true
         request!!.requestURI = "/api/v1/data"
         request!!.method = "POST"
-        subject!!.preHandle(request!!, response!!, Any())
-        assertThat(response!!.status, `is`(503))
+        assertThrows<ReadOnlyException> {
+            subject!!.preHandle(request!!, response!!, Any())
+        }
     }
 
     @Test

--- a/components/permissions/build.gradle
+++ b/components/permissions/build.gradle
@@ -23,7 +23,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation('org.springframework.boot:spring-boot-starter-validation')
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("junit:junit")
 
     implementation('tools.jackson.module:jackson-module-kotlin')
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/entities/PermissionDataTest.kt
+++ b/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/entities/PermissionDataTest.kt
@@ -2,19 +2,16 @@ package org.cloudfoundry.credhub.entities
 
 import org.cloudfoundry.credhub.PermissionOperation
 import org.cloudfoundry.credhub.data.PermissionData
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.util.Arrays
 
-@RunWith(JUnit4::class)
 class PermissionDataTest {
     private var permissionData: PermissionData? = null
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
     fun setUp() {
         permissionData = PermissionData()

--- a/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/requests/PermissionEntryTest.kt
+++ b/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/requests/PermissionEntryTest.kt
@@ -9,14 +9,12 @@ import org.cloudfoundry.credhub.utils.AuthConstants.Companion.USER_A_PATH
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.contains
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import tools.jackson.databind.ObjectMapper
 import tools.jackson.databind.exc.InvalidFormatException
 import java.io.IOException
 
-@RunWith(JUnit4::class)
 class PermissionEntryTest {
     @Test
     @Throws(IOException::class)
@@ -68,11 +66,12 @@ class PermissionEntryTest {
         )
     }
 
-    @Test(expected = InvalidFormatException::class)
-    @Throws(Throwable::class)
+    @Test
     fun validation_ensuresOperationsAreAllValid() {
         val json = ("{ \n\"actor\": \"$USER_A_ACTOR_ID\",\n\"operations\": [\"foo\", \"read\"],\n\"path\": \"$USER_A_PATH\"}")
-        deserializeAndValidate<PermissionEntry>(json, PermissionEntry::class.java)
+        assertThrows<InvalidFormatException> {
+            deserializeAndValidate<PermissionEntry>(json, PermissionEntry::class.java)
+        }
     }
 
     @Test

--- a/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/requests/PermissionsRequestTest.kt
+++ b/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/requests/PermissionsRequestTest.kt
@@ -15,11 +15,8 @@ import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.hasProperty
 import org.hamcrest.core.IsEqual.equalTo
 import org.hamcrest.core.IsIterableContaining.hasItems
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 
-@RunWith(JUnit4::class)
 class PermissionsRequestTest {
     @Test
     fun validation_allowsGoodJson() {

--- a/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/requests/PermissionsV2RequestTest.kt
+++ b/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/requests/PermissionsV2RequestTest.kt
@@ -6,11 +6,8 @@ import org.hamcrest.MatcherAssert
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.collection.IsIterableContainingInOrder
 import org.hamcrest.core.IsEqual.equalTo
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 
-@RunWith(JUnit4::class)
 class PermissionsV2RequestTest {
     @Test
     fun whenPathEndsWithSlash_shouldBeInvalid() {

--- a/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/services/DefaultCredentialServiceTest.kt
+++ b/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/services/DefaultCredentialServiceTest.kt
@@ -29,8 +29,8 @@ import org.cloudfoundry.credhub.requests.GenerationParameters
 import org.cloudfoundry.credhub.requests.PermissionEntry
 import org.cloudfoundry.credhub.requests.StringGenerationParameters
 import org.cloudfoundry.credhub.utils.TestConstants
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers
 import org.mockito.Mock
 import org.mockito.Mockito.any
@@ -81,7 +81,7 @@ class DefaultCredentialServiceTest {
     private lateinit var certificate: CertificateCredentialVersion
     private lateinit var certUuid: UUID
 
-    @Before
+    @BeforeEach
     fun setUp() {
         openMocks(this)
 

--- a/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/services/DefaultPermissionCheckingServiceTest.kt
+++ b/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/services/DefaultPermissionCheckingServiceTest.kt
@@ -1,8 +1,5 @@
 package org.cloudfoundry.credhub.services
 
-import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertFalse
-import junit.framework.TestCase.assertTrue
 import org.cloudfoundry.credhub.PermissionOperation
 import org.cloudfoundry.credhub.PermissionOperation.DELETE
 import org.cloudfoundry.credhub.PermissionOperation.READ
@@ -14,23 +11,23 @@ import org.cloudfoundry.credhub.auth.UserContextHolder
 import org.cloudfoundry.credhub.data.PermissionDataService
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.springframework.test.util.ReflectionTestUtils
 import java.util.UUID
 
-@RunWith(JUnit4::class)
 class DefaultPermissionCheckingServiceTest {
     private var subject: DefaultPermissionCheckingService? = null
 
     private var userContext: UserContext? = null
     private var permissionDataService: PermissionDataService? = null
 
-    @Before
+    @BeforeEach
     fun beforeEach() {
         userContext = mock(UserContext::class.java)
         `when`(userContext!!.actor).thenReturn("test-actor")

--- a/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/services/DefaultPermissionServiceTest.kt
+++ b/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/services/DefaultPermissionServiceTest.kt
@@ -18,11 +18,9 @@ import org.cloudfoundry.credhub.requests.PermissionEntry
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.core.IsEqual
-import org.junit.Assert.fail
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.ArgumentMatchers.eq
@@ -33,7 +31,6 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import java.util.Arrays.asList
 
-@RunWith(JUnit4::class)
 class DefaultPermissionServiceTest {
     private var subject: DefaultPermissionService? = null
 
@@ -46,7 +43,7 @@ class DefaultPermissionServiceTest {
 
     private fun <T> any(type: Class<T>): T = Mockito.any<T>(type)
 
-    @Before
+    @BeforeEach
     fun beforeEach() {
         userContext = mock(UserContext::class.java)
         `when`(userContext!!.actor).thenReturn(USER_NAME)

--- a/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/services/PermissionDataServiceTest.kt
+++ b/components/permissions/src/test/kotlin/org/cloudfoundry/credhub/services/PermissionDataServiceTest.kt
@@ -1,7 +1,6 @@
 package org.cloudfoundry.credhub.services
 
 import com.google.common.collect.Lists.newArrayList
-import junit.framework.TestCase.assertFalse
 import org.apache.commons.lang3.RandomStringUtils
 import org.cloudfoundry.credhub.CredhubTestApp
 import org.cloudfoundry.credhub.ErrorMessages
@@ -35,16 +34,17 @@ import org.hamcrest.collection.IsCollectionWithSize.hasSize
 import org.hamcrest.core.Is.`is`
 import org.hamcrest.core.IsEqual.equalTo
 import org.hamcrest.core.IsIterableContaining.hasItems
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.transaction.annotation.Transactional
 
-@RunWith(SpringRunner::class)
+@ExtendWith(SpringExtension::class)
 @ActiveProfiles(value = ["unit-test"], resolver = DatabaseProfileResolver::class)
 @SpringBootTest(classes = [CredhubTestApp::class])
 @Transactional
@@ -61,7 +61,7 @@ class PermissionDataServiceTest {
     private var aces: List<PermissionEntry>? = null
     private var credential: Credential? = null
 
-    @Before
+    @BeforeEach
     fun beforeEach() {
         seedDatabase()
     }

--- a/components/string-utilities/build.gradle
+++ b/components/string-utilities/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("junit:junit")
 
     implementation('tools.jackson.module:jackson-module-kotlin')
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/components/string-utilities/src/test/kotlin/org/cloudfoundry/credhub/config/VersionProviderTest.kt
+++ b/components/string-utilities/src/test/kotlin/org/cloudfoundry/credhub/config/VersionProviderTest.kt
@@ -4,13 +4,10 @@ import org.cloudfoundry.credhub.utils.ResourceReader
 import org.cloudfoundry.credhub.utils.VersionProvider
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 
-@RunWith(JUnit4::class)
 class VersionProviderTest {
     @Test
     @Throws(Exception::class)

--- a/components/time-support/build.gradle
+++ b/components/time-support/build.gradle
@@ -17,7 +17,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("junit:junit")
 
     implementation('tools.jackson.module:jackson-module-kotlin')
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/components/time-support/src/test/kotlin/org/cloudfoundry/credhub/utils/InstantMillisecondsConverterTest.kt
+++ b/components/time-support/src/test/kotlin/org/cloudfoundry/credhub/utils/InstantMillisecondsConverterTest.kt
@@ -3,12 +3,9 @@ package org.cloudfoundry.credhub.utils
 import org.cloudfoundry.credhub.util.InstantMillisecondsConverter
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.jupiter.api.Test
 import java.time.Instant
 
-@RunWith(JUnit4::class)
 class InstantMillisecondsConverterTest {
     private var subject = InstantMillisecondsConverter()
 

--- a/components/time-support/src/test/kotlin/org/cloudfoundry/credhub/utils/TimedRetryTest.kt
+++ b/components/time-support/src/test/kotlin/org/cloudfoundry/credhub/utils/TimedRetryTest.kt
@@ -3,8 +3,8 @@ package org.cloudfoundry.credhub.utils
 import org.cloudfoundry.credhub.util.TimedRetry
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.util.function.Supplier
 
 class TimedRetryTest {
@@ -16,7 +16,7 @@ class TimedRetryTest {
     private var durationInSeconds: Long = 0
     private var endTime: Long = 0
 
-    @Before
+    @BeforeEach
     @Throws(Exception::class)
     fun setup() {
         currentTimeProvider = FakeCurrentTimeProvider()


### PR DESCRIPTION
org.springframework.test.context.junit4.SpringRunner with the JUnit Jupiter org.springframework.test.context.junit.jupiter.SpringExtension.

Annotation and import changes:
- @RunWith(SpringRunner) → @ExtendWith(SpringExtension::class/.class)
- @RunWith(JUnit4) → removed (no runner needed for plain unit tests)
- @RunWith(Parameterized) → @ExtendWith(SpringExtension) + @ParameterizedTest with @MethodSource per method (CredentialsTypeSpecific*IntegrationTest)
- @Before/@After/@BeforeClass/@AfterClass → @BeforeEach/@AfterEach/@BeforeAll/@AfterAll
- @Ignore → @Disabled
- @Test(expected=X) → assertThrows(X.class, ...) / assertThrows<X> { }
- @Rule Timeout → @Timeout(60, unit = TimeUnit.SECONDS) on class
- SpringClassRule/SpringMethodRule → removed (replaced by SpringExtension)
- junit.Assert/Assume → junit.jupiter.api.Assertions/Assumptions (note: Assume.assumeTrue(msg, cond) arg order reversed to Assumptions.assumeTrue(cond, msg))
- junit.framework.TestCase.* → junit.jupiter.api.Assertions.*

Build infrastructure:
- Added useJUnitPlatform() globally in root subprojects block
- Added testRuntimeOnly("org.junit.platform:junit-platform-launcher") globally (required by Gradle's isolated test process to bootstrap JUnit Platform)
- Removed testImplementation("junit:junit") from all 11 modules that declared it

Test quality fix (EncryptorTest):
- decrypt_failsToEncryptWhenGivenWrongKeyUuid was a false positive under JUnit 4: an unstubbed mock returned null causing NPE before the line under test was ever reached, which @Test(expected=RuntimeException) masked. Replaced with explicit stubs keyed on newUuid (succeeds) vs oldUuid (throws), verifying the actual decrypt-with-wrong-key behavior.

ai-assisted=yes