### PR TITLE
docs: Restore lost certificate version create and delete API doc sect…

### DIFF
--- a/backends/credhub/src/docs/asciidoc/snippets/certificates-v1.adoc
+++ b/backends/credhub/src/docs/asciidoc/snippets/certificates-v1.adoc
@@ -52,3 +52,13 @@ operation::getCertificateVersionsReturnsCertificates[]
 
 Note: The certificate versions will be sorted in descending order of their creation date.
 
+---
+
+=== Create a Version of a Certificate
+operation::postCertificateVersionsReturnsCertificate[]
+
+---
+
+=== Delete a Version of a Certificate
+operation::deleteCertificateVersionReturnsCertificate[]
+

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/certificates/CertificatesControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/certificates/CertificatesControllerTest.kt
@@ -859,7 +859,7 @@ class CertificatesControllerTest {
     }
 
     @Test
-    fun getCertificateVersionsReturnsCertificate() {
+    fun postCertificateVersionsReturnsCertificate() {
         val expectedCertificateCredentialValue =
             CertificateCredentialValue(
                 TestConstants.TEST_CA,
@@ -943,7 +943,7 @@ class CertificatesControllerTest {
     }
 
     @Test
-    fun deleteRertificateVersionReturnsCertificate() {
+    fun deleteCertificateVersionReturnsCertificate() {
         val versionId = UUID.randomUUID()
         spyCertificatesHandler.handledeleteversionrequestReturnsCertificateview = certificateView
 


### PR DESCRIPTION
…ions

- The "Create a Version of a Certificate" and "Delete a Version of a Certificate" sections were accidentally dropped from certificates-v1.adoc in b1e236c79 when snippet operation names were renamed to match test names, but the two POST/DELETE tests had been misnamed (wrong verb prefix, typo) so the sections were removed rather than updated.
- Fixed the test method names and restore the adoc sections so the generated API documentation covers these endpoints again.

ai-assisted=yes