### PR TITLE
migration: deprecated @GeneratedValue(generator = "uuid2") to @UuidGe…

### DIFF
--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/entity/Credential.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/entity/Credential.kt
@@ -4,13 +4,13 @@ import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
-import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import org.apache.commons.codec.digest.DigestUtils
 import org.cloudfoundry.credhub.audit.AuditableCredential
 import org.cloudfoundry.credhub.constants.UuidConstants.Companion.UUID_BYTES
+import org.hibernate.annotations.UuidGenerator
 import java.util.UUID
 
 @Entity
@@ -18,7 +18,7 @@ import java.util.UUID
 class Credential : AuditableCredential {
     @Id
     @Column(length = UUID_BYTES)
-    @GeneratedValue(generator = "uuid2")
+    @UuidGenerator
     override var uuid: UUID? = null
 
     @OneToMany(

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/entity/CredentialVersionData.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/entity/CredentialVersionData.kt
@@ -7,7 +7,6 @@ import jakarta.persistence.DiscriminatorColumn
 import jakarta.persistence.DiscriminatorType
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
-import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.Inheritance
 import jakarta.persistence.InheritanceType
@@ -21,6 +20,7 @@ import org.cloudfoundry.credhub.util.InstantMillisecondsConverter
 import org.cloudfoundry.credhub.utils.JsonNodeConverter
 import org.hibernate.annotations.NotFound
 import org.hibernate.annotations.NotFoundAction
+import org.hibernate.annotations.UuidGenerator
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import tools.jackson.databind.JsonNode
@@ -37,7 +37,7 @@ abstract class CredentialVersionData<Z : CredentialVersionData<Z>>(
 ) {
     @Id
     @Column(length = UuidConstants.UUID_BYTES)
-    @GeneratedValue(generator = "uuid2")
+    @UuidGenerator
     open var uuid: UUID? = null
 
     @OneToOne(cascade = [CascadeType.ALL])

--- a/components/encryption/src/main/java/org/cloudfoundry/credhub/entities/EncryptedValue.java
+++ b/components/encryption/src/main/java/org/cloudfoundry/credhub/entities/EncryptedValue.java
@@ -12,13 +12,13 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.cloudfoundry.credhub.constants.EncryptionConstants;
 import org.cloudfoundry.credhub.constants.UuidConstants;
 import org.cloudfoundry.credhub.util.InstantMillisecondsConverter;
+import org.hibernate.annotations.UuidGenerator;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -31,7 +31,7 @@ public class EncryptedValue {
 
   @Id
   @Column(length = UuidConstants.UUID_BYTES)
-  @GeneratedValue(generator = "uuid2")
+  @UuidGenerator
   private UUID uuid;
 
   @Convert(converter = InstantMillisecondsConverter.class)

--- a/components/permissions/src/main/kotlin/org/cloudfoundry/credhub/data/PermissionData.kt
+++ b/components/permissions/src/main/kotlin/org/cloudfoundry/credhub/data/PermissionData.kt
@@ -2,7 +2,6 @@ package org.cloudfoundry.credhub.data
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.cloudfoundry.credhub.PermissionOperation
@@ -13,6 +12,7 @@ import org.cloudfoundry.credhub.PermissionOperation.WRITE
 import org.cloudfoundry.credhub.PermissionOperation.WRITE_ACL
 import org.cloudfoundry.credhub.audit.AuditablePermissionData
 import org.cloudfoundry.credhub.constants.UuidConstants
+import org.hibernate.annotations.UuidGenerator
 import java.util.UUID
 
 @Entity
@@ -25,7 +25,7 @@ class PermissionData(
 ) : AuditablePermissionData {
     @Id
     @Column(length = UuidConstants.UUID_BYTES)
-    @GeneratedValue(generator = "uuid2")
+    @UuidGenerator
     override var uuid: UUID? = null
 
     @Column(name = "read_permission", nullable = false)


### PR DESCRIPTION
…nerator

- The "uuid2" generator name is resolved to the deprecated org.hibernate.id.UUIDGenerator (deprecated since Hibernate 6.0).
- Replaced it with @org.hibernate.annotations.UuidGenerator, which is backed by the replacement org.hibernate.id.uuid.UuidGenerator, across all four affected entities: EncryptedValue, Credential, CredentialVersionData, and PermissionData.

ai-assisted=yes

TNZ-99252