### PR TITLE
chore: deprecated API usage removal

### DIFF
--- a/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialSetErrorHandlingTest.java
+++ b/backends/credhub/src/test/java/org/cloudfoundry/credhub/integration/CredentialSetErrorHandlingTest.java
@@ -380,7 +380,7 @@ public class CredentialSetErrorHandlingTest {
 
     final String expectedError = "Value exceeds the maximum size.";
     mockMvc.perform(request)
-      .andExpect(status().isPayloadTooLarge())
+      .andExpect(status().isContentTooLarge())
       .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
       .andExpect(jsonPath("$.error").value(expectedError));
   }


### PR DESCRIPTION
- Replaced `org.springframework.test.web.servlet.result.StatusResultMatchers.isPayloadTooLarge` with `org.springframework.test.web.servlet.result.StatusResultMatchers.isContentTooLarge`.

ai-assisted=no
TNZ-99253