### PR TITLE
fix:  No snippets found for API doc generation

### DIFF
--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/certificates/CertificatesControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/certificates/CertificatesControllerTest.kt
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType
 import org.springframework.restdocs.ManualRestDocumentation
@@ -73,8 +74,8 @@ class CertificatesControllerTest {
     }
 
     @BeforeEach
-    fun setUp() {
-        restDocumentation.beforeTest(javaClass, javaClass.simpleName)
+    fun setUp(testInfo: TestInfo) {
+        restDocumentation.beforeTest(javaClass, testInfo.testMethod.get().name)
         spyCertificatesHandler = SpyCertificatesHandler()
 
         val certificateController =

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerDeleteTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerDeleteTest.kt
@@ -10,6 +10,7 @@ import org.cloudfoundry.credhub.helpers.MockMvcFactory
 import org.cloudfoundry.credhub.helpers.credHubAuthHeader
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -41,8 +42,8 @@ class CredentialsControllerDeleteTest {
     }
 
     @BeforeEach
-    fun setUp() {
-        restDocumentation.beforeTest(javaClass, javaClass.simpleName)
+    fun setUp(testInfo: TestInfo) {
+        restDocumentation.beforeTest(javaClass, testInfo.testMethod.get().name)
         val credentialController =
             CredentialsController(
                 spyCredentialsHandler,

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerDeleteTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerDeleteTest.kt
@@ -10,10 +10,10 @@ import org.cloudfoundry.credhub.helpers.MockMvcFactory
 import org.cloudfoundry.credhub.helpers.credHubAuthHeader
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
 import org.springframework.http.MediaType
 import org.springframework.restdocs.ManualRestDocumentation
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerGenerateTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerGenerateTest.kt
@@ -26,10 +26,10 @@ import org.cloudfoundry.credhub.utils.TestConstants
 import org.cloudfoundry.credhub.views.CertificateGenerationView
 import org.cloudfoundry.credhub.views.CredentialView
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerGenerateTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerGenerateTest.kt
@@ -26,6 +26,7 @@ import org.cloudfoundry.credhub.utils.TestConstants
 import org.cloudfoundry.credhub.views.CertificateGenerationView
 import org.cloudfoundry.credhub.views.CredentialView
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -78,8 +79,8 @@ class CredentialsControllerGenerateTest {
     }
 
     @BeforeEach
-    fun setUp() {
-        restDocumentation.beforeTest(javaClass, javaClass.simpleName)
+    fun setUp(testInfo: TestInfo) {
+        restDocumentation.beforeTest(javaClass, testInfo.testMethod.get().name)
 
         val credentialController =
             CredentialsController(

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerGetTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerGetTest.kt
@@ -21,6 +21,7 @@ import org.cloudfoundry.credhub.views.CredentialView
 import org.cloudfoundry.credhub.views.DataResponse
 import org.cloudfoundry.credhub.views.FindCredentialResult
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -63,8 +64,8 @@ class CredentialsControllerGetTest {
     }
 
     @BeforeEach
-    fun setUp() {
-        restDocumentation.beforeTest(javaClass, javaClass.simpleName)
+    fun setUp(testInfo: TestInfo) {
+        restDocumentation.beforeTest(javaClass, testInfo.testMethod.get().name)
         spyCredentialsHandler = SpyCredentialsHandler()
         spyRegenerateHandler = SpyRegenerateHandler()
 

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerGetTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerGetTest.kt
@@ -21,10 +21,10 @@ import org.cloudfoundry.credhub.views.CredentialView
 import org.cloudfoundry.credhub.views.DataResponse
 import org.cloudfoundry.credhub.views.FindCredentialResult
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.extension.ExtendWith
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerSetTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerSetTest.kt
@@ -27,10 +27,10 @@ import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
 import org.cloudfoundry.credhub.utils.TestConstants
 import org.cloudfoundry.credhub.views.CredentialView
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.extension.ExtendWith
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerSetTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/credentials/CredentialsControllerSetTest.kt
@@ -27,6 +27,7 @@ import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
 import org.cloudfoundry.credhub.utils.TestConstants
 import org.cloudfoundry.credhub.views.CredentialView
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -70,8 +71,8 @@ class CredentialsControllerSetTest {
     }
 
     @BeforeEach
-    fun setUp() {
-        restDocumentation.beforeTest(javaClass, javaClass.simpleName)
+    fun setUp(testInfo: TestInfo) {
+        restDocumentation.beforeTest(javaClass, testInfo.testMethod.get().name)
         val credentialController =
             CredentialsController(
                 spyCredentialsHandler,

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/health/HealthControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/health/HealthControllerTest.kt
@@ -6,6 +6,7 @@ import org.cloudfoundry.credhub.helpers.MockMvcFactory
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.extension.ExtendWith
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.restdocs.ManualRestDocumentation
@@ -26,8 +27,8 @@ class HealthControllerTest {
     private lateinit var healthController: HealthController
 
     @BeforeEach
-    fun setUp() {
-        restDocumentation.beforeTest(javaClass, javaClass.simpleName)
+    fun setUp(testInfo: TestInfo) {
+        restDocumentation.beforeTest(javaClass, testInfo.testMethod.get().name)
         healthController = HealthController()
 
         mockMvc =

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/info/InfoControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/info/InfoControllerTest.kt
@@ -7,10 +7,10 @@ import org.cloudfoundry.credhub.helpers.credHubAuthHeader
 import org.cloudfoundry.credhub.info.InfoController
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.extension.ExtendWith
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/info/InfoControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/info/InfoControllerTest.kt
@@ -7,6 +7,7 @@ import org.cloudfoundry.credhub.helpers.credHubAuthHeader
 import org.cloudfoundry.credhub.info.InfoController
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -38,8 +39,8 @@ class InfoControllerTest {
     }
 
     @BeforeEach
-    fun setUp() {
-        restDocumentation.beforeTest(javaClass, javaClass.simpleName)
+    fun setUp(testInfo: TestInfo) {
+        restDocumentation.beforeTest(javaClass, testInfo.testMethod.get().name)
         uaaUrl = "https://uaa.url.example.com"
 
         val infoController = InfoController(uaaUrl)

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/interpolate/InterpolateControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/interpolate/InterpolateControllerTest.kt
@@ -9,10 +9,10 @@ import org.cloudfoundry.credhub.helpers.credHubAuthHeader
 import org.cloudfoundry.credhub.interpolation.InterpolationController
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType
 import org.springframework.restdocs.ManualRestDocumentation

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/interpolate/InterpolateControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/interpolate/InterpolateControllerTest.kt
@@ -9,6 +9,7 @@ import org.cloudfoundry.credhub.helpers.credHubAuthHeader
 import org.cloudfoundry.credhub.interpolation.InterpolationController
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -38,8 +39,8 @@ class InterpolateControllerTest {
     }
 
     @BeforeEach
-    fun setUp() {
-        restDocumentation.beforeTest(javaClass, javaClass.simpleName)
+    fun setUp(testInfo: TestInfo) {
+        restDocumentation.beforeTest(javaClass, testInfo.testMethod.get().name)
         spyInterpolationHandler = SpyInterpolationHandler()
 
         val interpolationController =

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/keyusage/KeyUsageControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/keyusage/KeyUsageControllerTest.kt
@@ -7,6 +7,7 @@ import org.cloudfoundry.credhub.helpers.credHubAuthHeader
 import org.cloudfoundry.credhub.keyusage.KeyUsageController
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -36,8 +37,8 @@ class KeyUsageControllerTest {
     }
 
     @BeforeEach
-    fun setUp() {
-        restDocumentation.beforeTest(javaClass, javaClass.simpleName)
+    fun setUp(testInfo: TestInfo) {
+        restDocumentation.beforeTest(javaClass, testInfo.testMethod.get().name)
         keyUsageHandler = SpyKeyUsageHandler()
         val keyUsageController = KeyUsageController(keyUsageHandler)
 

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/keyusage/KeyUsageControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/keyusage/KeyUsageControllerTest.kt
@@ -7,10 +7,10 @@ import org.cloudfoundry.credhub.helpers.credHubAuthHeader
 import org.cloudfoundry.credhub.keyusage.KeyUsageController
 import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType
 import org.springframework.restdocs.ManualRestDocumentation

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/management/ManagementControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/management/ManagementControllerTest.kt
@@ -8,6 +8,7 @@ import org.cloudfoundry.credhub.management.ManagementController
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.extension.ExtendWith
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType
@@ -30,8 +31,8 @@ class ManagementControllerTest {
     lateinit var spyManagementService: SpyManagementService
 
     @BeforeEach
-    fun setUp() {
-        restDocumentation.beforeTest(javaClass, javaClass.simpleName)
+    fun setUp(testInfo: TestInfo) {
+        restDocumentation.beforeTest(javaClass, testInfo.testMethod.get().name)
         spyManagementService = SpyManagementService()
 
         val managementController = ManagementController(spyManagementService)

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/permissions/PermissionsV1ControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/permissions/PermissionsV1ControllerTest.kt
@@ -14,6 +14,7 @@ import org.cloudfoundry.credhub.views.PermissionsView
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType
 import org.springframework.restdocs.ManualRestDocumentation
@@ -40,8 +41,8 @@ class PermissionsV1ControllerTest {
     lateinit var spyPermissionsV1Handler: SpyPermissionsV1Handler
 
     @BeforeEach
-    fun setUp() {
-        restDocumentation.beforeTest(javaClass, javaClass.simpleName)
+    fun setUp(testInfo: TestInfo) {
+        restDocumentation.beforeTest(javaClass, testInfo.testMethod.get().name)
         spyPermissionsV1Handler = SpyPermissionsV1Handler()
         val permissionsV1Controller = PermissionsV1Controller(spyPermissionsV1Handler, CEFAuditRecord())
 

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/regenerate/RegenerateControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/regenerate/RegenerateControllerTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.extension.ExtendWith
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType
@@ -52,8 +53,8 @@ class RegenerateControllerTest {
     }
 
     @BeforeEach
-    fun beforeEach() {
-        restDocumentation.beforeTest(javaClass, javaClass.simpleName)
+    fun beforeEach(testInfo: TestInfo) {
+        restDocumentation.beforeTest(javaClass, testInfo.testMethod.get().name)
         spyRegenerateHandler = SpyRegenerateHandler()
         val regenerateController = RegenerateController(spyRegenerateHandler)
 

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/versions/VersionControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/versions/VersionControllerTest.kt
@@ -8,6 +8,7 @@ import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
 import org.cloudfoundry.credhub.utils.VersionProvider
 import org.cloudfoundry.credhub.versions.VersionController
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -36,8 +37,8 @@ class VersionControllerTest {
     }
 
     @BeforeEach
-    fun setUp() {
-        restDocumentation.beforeTest(javaClass, javaClass.simpleName)
+    fun setUp(testInfo: TestInfo) {
+        restDocumentation.beforeTest(javaClass, testInfo.testMethod.get().name)
         versionProvider = Mockito.mock(VersionProvider::class.java)
 
         val versionController = VersionController(versionProvider)

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/versions/VersionControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v1/versions/VersionControllerTest.kt
@@ -8,10 +8,10 @@ import org.cloudfoundry.credhub.utils.BouncyCastleFipsConfigurer
 import org.cloudfoundry.credhub.utils.VersionProvider
 import org.cloudfoundry.credhub.versions.VersionController
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
 import org.mockito.Mockito
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType

--- a/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v2/permissions/PermissionsV2ControllerTest.kt
+++ b/backends/credhub/src/test/kotlin/org/cloudfoundry/credhub/controllers/v2/permissions/PermissionsV2ControllerTest.kt
@@ -13,6 +13,7 @@ import org.cloudfoundry.credhub.views.PermissionsV2View
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInfo
 import org.skyscreamer.jsonassert.JSONAssert
 import org.springframework.http.MediaType
 import org.springframework.restdocs.ManualRestDocumentation
@@ -42,8 +43,8 @@ class PermissionsV2ControllerTest {
     lateinit var spyPermissionsV2Handler: SpyPermissionsV2Handler
 
     @BeforeEach
-    fun setUp() {
-        restDocumentation.beforeTest(javaClass, javaClass.simpleName)
+    fun setUp(testInfo: TestInfo) {
+        restDocumentation.beforeTest(javaClass, testInfo.testMethod.get().name)
         spyPermissionsV2Handler = SpyPermissionsV2Handler()
         val permissionsV2Controller = PermissionsV2Controller(spyPermissionsV2Handler)
 


### PR DESCRIPTION
- Changed to use TestInfo to provide accurate test method names for REST documentation.
- Updated @BeforeEach setUp methods across 14 controller test classes to inject TestInfo.
- Changed restDocumentation.beforeTest() to use testInfo.testMethod.get().name instead of javaClass.simpleName.
- Ensureed REST documentation snippets are generated with unique identifiers per test method rather than the class name.

ai-assisted=yes
TNZ-100436