### PR TITLE
refactor: replace deprecated X509Configurer#subjectPrincipalRegex wit…

### DIFF
--- a/components/auth/src/main/java/org/cloudfoundry/credhub/auth/MtlsX509PrincipalExtractor.java
+++ b/components/auth/src/main/java/org/cloudfoundry/credhub/auth/MtlsX509PrincipalExtractor.java
@@ -1,0 +1,49 @@
+package org.cloudfoundry.credhub.auth;
+
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import javax.naming.InvalidNameException;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
+import javax.security.auth.x500.X500Principal;
+
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.web.authentication.preauth.x509.X509PrincipalExtractor;
+
+/**
+ * Extracts the principal from the OU attribute of the client certificate's Subject DN.
+ * Cloud Foundry mTLS certificates carry the app identity as {@code OU=app:<uuid-v4>}.
+ * Throws {@link BadCredentialsException} if the OU is absent or does not match the
+ * expected {@code app:<uuid-v4>} format.
+ */
+public class MtlsX509PrincipalExtractor implements X509PrincipalExtractor {
+
+    private static final Pattern MTLS_ID_PATTERN =
+            Pattern.compile("app:[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}");
+
+    @Override
+    public Object extractPrincipal(X509Certificate clientCert) {
+        X500Principal principal = clientCert.getSubjectX500Principal();
+        String subjectDn = principal.getName(X500Principal.RFC2253);
+        List<Rdn> rdns;
+        try {
+            rdns = new LdapName(subjectDn).getRdns();
+        } catch (InvalidNameException ex) {
+            throw new BadCredentialsException("Failed to parse client certificate subject DN", ex);
+        }
+        for (Rdn rdn : rdns) {
+            if ("OU".equals(rdn.getType())) {
+                String ouValue = String.valueOf(rdn.getValue());
+                if (!MTLS_ID_PATTERN.matcher(ouValue).matches()) {
+                    throw new BadCredentialsException(
+                            "OU attribute does not match expected mTLS identity format: " + ouValue);
+                }
+                return ouValue;
+            }
+        }
+        throw new BadCredentialsException(
+                "No OU attribute found in client certificate subject DN: " + subjectDn);
+    }
+}

--- a/components/auth/src/main/java/org/cloudfoundry/credhub/config/AuthConfiguration.java
+++ b/components/auth/src/main/java/org/cloudfoundry/credhub/config/AuthConfiguration.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.cloudfoundry.credhub.auth.ActuatorPortFilter;
 import org.cloudfoundry.credhub.auth.CredHubJwtTimeValidator;
+import org.cloudfoundry.credhub.auth.MtlsX509PrincipalExtractor;
 import org.cloudfoundry.credhub.auth.OAuth2AuthenticationExceptionHandler;
 import org.cloudfoundry.credhub.auth.OAuth2IssuerService;
 import org.cloudfoundry.credhub.auth.PreAuthenticationFailureFilter;
@@ -48,7 +49,6 @@ import static org.springframework.security.config.Customizer.withDefaults;
 @Configuration
 @EnableWebSecurity
 public class AuthConfiguration {
-    private static final String VALID_MTLS_ID = "\\bOU=(app:[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12})\\b";
     private static final Logger LOGGER = LogManager.getLogger(AuthConfiguration.class.getName());
 
     @Autowired
@@ -66,7 +66,7 @@ public class AuthConfiguration {
 
         http.x509(configurer -> {
             configurer
-                    .subjectPrincipalRegex(VALID_MTLS_ID)
+                    .x509PrincipalExtractor(new MtlsX509PrincipalExtractor())
                     .userDetailsService(mtlsSUserDetailsService())
                     .withObjectPostProcessor(
                             new ObjectPostProcessor<X509AuthenticationFilter>() {

--- a/components/auth/src/main/java/org/cloudfoundry/credhub/config/AuthWithoutOAuthConfiguration.java
+++ b/components/auth/src/main/java/org/cloudfoundry/credhub/config/AuthWithoutOAuthConfiguration.java
@@ -19,6 +19,7 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedA
 import org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter;
 import org.springframework.web.filter.UrlHandlerFilter;
 
+import org.cloudfoundry.credhub.auth.MtlsX509PrincipalExtractor;
 import org.cloudfoundry.credhub.auth.PreAuthenticationFailureFilter;
 import org.cloudfoundry.credhub.auth.X509AuthenticationProvider;
 
@@ -26,7 +27,6 @@ import org.cloudfoundry.credhub.auth.X509AuthenticationProvider;
 @Configuration
 @EnableWebSecurity
 public class AuthWithoutOAuthConfiguration {
-    private static final String VALID_MTLS_ID = "\\bOU=(app:[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12})\\b";
 
     @Autowired
     PreAuthenticationFailureFilter preAuthenticationFailureFilter;
@@ -36,7 +36,7 @@ public class AuthWithoutOAuthConfiguration {
 
         http.x509(configurer -> {
             configurer
-                    .subjectPrincipalRegex(VALID_MTLS_ID)
+                    .x509PrincipalExtractor(new MtlsX509PrincipalExtractor())
                     .userDetailsService(mtlsSUserDetailsService())
                     .withObjectPostProcessor(
                             new ObjectPostProcessor<X509AuthenticationFilter>() {

--- a/components/auth/src/main/kotlin/org/cloudfoundry/credhub/auth/X509AuthenticationFailureHandler.kt
+++ b/components/auth/src/main/kotlin/org/cloudfoundry/credhub/auth/X509AuthenticationFailureHandler.kt
@@ -26,12 +26,10 @@ class X509AuthenticationFailureHandler
             response: HttpServletResponse,
             exception: AuthenticationException,
         ) {
-            if (exception.message.toString().contains(INVALID_DN_MESSAGE)) {
-                writeUnauthorizedResponse(response, INVALID_MTLS_ID_RESPONSE)
-            }
-
             if (exception.message.toString().contains("Certificate does not contain: $CLIENT_AUTH_EXTENDED_KEY_USAGE")) {
                 writeUnauthorizedResponse(response, INVALID_CLIENT_AUTH_RESPONSE)
+            } else {
+                writeUnauthorizedResponse(response, INVALID_MTLS_ID_RESPONSE)
             }
         }
 
@@ -48,7 +46,6 @@ class X509AuthenticationFailureHandler
         }
 
         companion object {
-            private const val INVALID_DN_MESSAGE = "No matching pattern was found in subjectDN"
             private const val INVALID_MTLS_ID_RESPONSE = ErrorMessages.Auth.INVALID_MTLS_IDENTITY
             private const val INVALID_CLIENT_AUTH_RESPONSE = ErrorMessages.Auth.MTLS_NOT_CLIENT_AUTH
         }

--- a/components/auth/src/test/java/org/cloudfoundry/credhub/auth/MtlsX509PrincipalExtractorTest.java
+++ b/components/auth/src/test/java/org/cloudfoundry/credhub/auth/MtlsX509PrincipalExtractorTest.java
@@ -1,0 +1,64 @@
+package org.cloudfoundry.credhub.auth;
+
+import java.security.cert.X509Certificate;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.springframework.security.authentication.BadCredentialsException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MtlsX509PrincipalExtractorTest {
+
+    private static final String VALID_OU = "app:12345678-1234-4123-a123-123456789012";
+
+    private MtlsX509PrincipalExtractor extractor;
+    private X509Certificate cert;
+
+    @BeforeEach
+    public void setUp() {
+        extractor = new MtlsX509PrincipalExtractor();
+        cert = mock(X509Certificate.class);
+    }
+
+    private void givenSubjectDn(String dn) {
+        when(cert.getSubjectX500Principal()).thenReturn(new X500Principal(dn));
+    }
+
+    @Test
+    public void extractPrincipal_withValidMtlsOu_returnsPrincipal() {
+        givenSubjectDn("CN=test, OU=" + VALID_OU);
+
+        Object principal = extractor.extractPrincipal(cert);
+
+        assertEquals(VALID_OU, principal);
+    }
+
+    @Test
+    public void extractPrincipal_withNonV4UuidInOu_throwsBadCredentials() {
+        // Third UUID group starts with '1' (version 1), not '4'
+        givenSubjectDn("CN=test, OU=app:7e0fbd7d-14bd-11e7-a8b1-10ddb1aa64b3");
+
+        assertThrows(BadCredentialsException.class, () -> extractor.extractPrincipal(cert));
+    }
+
+    @Test
+    public void extractPrincipal_withOuMissingAppPrefix_throwsBadCredentials() {
+        givenSubjectDn("CN=test, OU=12345678-1234-4123-a123-123456789012");
+
+        assertThrows(BadCredentialsException.class, () -> extractor.extractPrincipal(cert));
+    }
+
+    @Test
+    public void extractPrincipal_withNoOuAttribute_throwsBadCredentials() {
+        givenSubjectDn("CN=test, O=org");
+
+        assertThrows(BadCredentialsException.class, () -> extractor.extractPrincipal(cert));
+    }
+}


### PR DESCRIPTION
…h X509PrincipalExtractor

- Created a custom X509PrincipalExtractor that parses Subject DN to extract OU attribute and validates the app:uuid-v4 format, throwing BadCredentialsException for invalid  or missing identities.
- Updated X509AuthenticationFailureHandler to handle new error messages.

ai-assisted=yes
TNZ-99256