### PR TITLE
Update dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,7 @@ updates:
   - dependency-name: "org.mariadb.jdbc:mariadb-java-client" ## version 3.0.3 of the driver drops support for Aurora - https://www.pivotaltracker.com/n/projects/2482247/stories/183282618
     update-types: ["version-update:semver-major"]
   - dependency-name: "org.springframework.boot:*"
-    update-types: [ "version-update:semver-major" ] # for now stay on the more stable v3, which will be supported until June 2026: https://spring.io/projects/spring-boot#support)
-  - dependency-name: "org.springframework.cloud:spring-cloud-contract-gradle-plugin"
-    # Needs to stay with version 4 as version 5 is incompatible with
-    # spring-framework 6. Wait till bumping spring-boot to version 4, which
-    # depends on spring-framework 7.
-    update-types: [ "version-update:semver-major" ]
+    update-types: [ "version-update:semver-major" ] # Do major version bumps manually as it will almost certainly require major migration.
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
- Stop ignoring spring-cloud-contract version bumps.
- Update the comment for spring-boot bump ignore.

ai-assisted=no
TNZ-106817