### PR TITLE
fix: remove unused repo.spring.io/plugins-release repository

### DIFF
--- a/applications/credhub-api/build.gradle
+++ b/applications/credhub-api/build.gradle
@@ -12,7 +12,6 @@ buildscript {
         }
         else {
             mavenCentral()
-            maven { url = "https://repo.spring.io/plugins-release" }
             maven { url = "https://plugins.gradle.org/m2/" }
         }
     }

--- a/backends/credhub/build.gradle
+++ b/backends/credhub/build.gradle
@@ -12,7 +12,6 @@ buildscript {
         }
         else {
             mavenCentral()
-            maven { url = "https://repo.spring.io/plugins-release" }
             maven { url = "https://plugins.gradle.org/m2/" }
         }
     }

--- a/backends/remote/build.gradle
+++ b/backends/remote/build.gradle
@@ -12,7 +12,6 @@ buildscript {
         }
         else {
             mavenCentral()
-            maven { url = "https://repo.spring.io/plugins-release" }
             maven { url = "https://plugins.gradle.org/m2/" }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ buildscript {
         }
         else {
             mavenCentral()
-            maven { url = "https://repo.spring.io/plugins-release" }
             maven { url = "https://plugins.gradle.org/m2/" }
         }
     }

--- a/components/credentials/build.gradle
+++ b/components/credentials/build.gradle
@@ -12,7 +12,6 @@ buildscript {
         }
         else {
             mavenCentral()
-            maven { url = "https://repo.spring.io/plugins-release" }
             maven { url = "https://plugins.gradle.org/m2/" }
         }
     }

--- a/components/encryption/build.gradle
+++ b/components/encryption/build.gradle
@@ -12,7 +12,6 @@ buildscript {
         }
         else {
             mavenCentral()
-            maven { url = "https://repo.spring.io/plugins-release" }
             maven { url = "https://plugins.gradle.org/m2/" }
         }
     }


### PR DESCRIPTION
- The repo.spring.io/plugins-release entry in each buildscript repositories block was originally added in 2016 to resolve org.springframework.build.gradle:propdeps-plugin, a Spring-internal Gradle plugin that added optional/provided dependency scopes.
- That plugin was dropped in February 2019 (dda21e20) when the build was split into Gradle subprojects, but the repository declaration was never removed. It has been an orphan for over six years.
- The stale entry causes Dependabot (and any local build that doesn't use Artifactory) to hit repo.spring.io/plugins-release for every plugin resolution before falling through to the Gradle Plugin Portal. The repo requires authentication, so every unauthenticated request receives a 401, producing noise in Dependabot logs and adding unnecessary latency to  each build classpath resolution.
- All current buildscript classpath dependencies are available on Maven Central or the Gradle Plugin Portal, so removing this entry has no functional impact.

ai-assisted=yes
TNZ-107155