### PR TITLE
fix: Dependabot tracking of Spring Cloud Contract version

### DIFF
--- a/applications/credhub-api/build.gradle
+++ b/applications/credhub-api/build.gradle
@@ -1,4 +1,7 @@
 buildscript {
+    ext {
+        springCloudContractVersion = '5.0.0'
+    }
     repositories {
         def artifactRepoUrl = System.getenv("ARTIFACTORY_URL")
         if (artifactRepoUrl != null) {
@@ -16,7 +19,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath("org.springframework.cloud:spring-cloud-contract-gradle-plugin:5.0.0")
+        classpath("org.springframework.cloud:spring-cloud-contract-gradle-plugin:${springCloudContractVersion}")
     }
 }
 
@@ -75,6 +78,7 @@ dependencies {
 
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    implementation platform("org.springframework.cloud:spring-cloud-contract-dependencies:${springCloudContractVersion}")
     testImplementation('org.springframework.cloud:spring-cloud-starter-contract-verifier')
 }
 
@@ -85,7 +89,6 @@ configurations.all {
 dependencyManagement {
     imports {
         mavenBom("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
-        mavenBom "org.springframework.cloud:spring-cloud-contract-dependencies:5.0.0"
     }
     dependencies {
         // rest-assured 5.5.6 (shipped by Spring Cloud Contract 5.0.0) is incompatible with


### PR DESCRIPTION
- Replace the io.spring.dependency-management mavenBom import for spring-cloud-contract-dependencies with Gradle's native platform() declaration. Dependabot cannot parse the mavenBom DSL, causing it to skip updates for both the BOM and the gradle plugin classpath entry.
- Bring back the springCloudContractVersion variable, which had been previously replaced with literal version values, as the change is unnecessary.

ai-assisted=yes
TNZ-107155

Tested the dependatbot detection of Spring Cloud Contract version locally with dependabot cli:
```
% dependabot update gradle /applications/credhub-api --local /Users/hs031209/prj/credhub
<snip>
updater | | created | org.springframework.cloud:spring-cloud-contract-gradle-plugin ( from 5.0.0 to 5.0.2 ), org.springframework.cloud:spri... |
```