### PR TITLE
Formatting updates for new rules introduced between ktlint-1.5 & 1.8

### DIFF
--- a/backends/credhub/src/main/kotlin/org/cloudfoundry/credhub/credentials/DefaultCredentialsHandler.kt
+++ b/backends/credhub/src/main/kotlin/org/cloudfoundry/credhub/credentials/DefaultCredentialsHandler.kt
@@ -89,15 +89,21 @@ class DefaultCredentialsHandler(
 
         val existingCredentialVersion =
             when {
-                activeVersionList.size > 1 && (activeVersionList[0] as CertificateCredentialVersion).isVersionTransitional ->
+                activeVersionList.size > 1 && (activeVersionList[0] as CertificateCredentialVersion).isVersionTransitional -> {
                     activeVersionList[1]
+                }
+
                 activeVersionList.isNotEmpty() &&
                     (
                         activeVersionList[0] !is CertificateCredentialVersion ||
                             !(activeVersionList[0] as CertificateCredentialVersion).isVersionTransitional
-                    ) ->
+                    ) -> {
                     activeVersionList[0]
-                else -> null
+                }
+
+                else -> {
+                    null
+                }
             }
 
         val value = credentialGenerator.generate(generateRequest)

--- a/backends/credhub/src/main/kotlin/org/cloudfoundry/credhub/credentials/RemoteCredentialsHandler.kt
+++ b/backends/credhub/src/main/kotlin/org/cloudfoundry/credhub/credentials/RemoteCredentialsHandler.kt
@@ -263,8 +263,14 @@ class RemoteCredentialsHandler(
         data: ByteString,
     ): CredentialValue =
         when (type) {
-            "value" -> StringCredentialValue(data.toStringUtf8())
-            "password" -> StringCredentialValue(data.toStringUtf8())
+            "value" -> {
+                StringCredentialValue(data.toStringUtf8())
+            }
+
+            "password" -> {
+                StringCredentialValue(data.toStringUtf8())
+            }
+
             "certificate" -> {
                 val jsonString = data.toStringUtf8()
                 val jsonNode = objectMapper.readTree(jsonString)
@@ -280,11 +286,13 @@ class RemoteCredentialsHandler(
                     jsonNode["transitional"]?.booleanValue() ?: false,
                 )
             }
+
             "json" -> {
                 val jsonString = data.toStringUtf8()
                 val jsonNode = objectMapper.readTree(jsonString)
                 JsonCredentialValue(jsonNode)
             }
+
             "user" -> {
                 val jsonString = data.toStringUtf8()
                 val jsonNode = objectMapper.readTree(jsonString)
@@ -294,6 +302,7 @@ class RemoteCredentialsHandler(
                     jsonNode["salt"]?.stringValue()!!,
                 )
             }
+
             "rsa" -> {
                 val jsonString = data.toStringUtf8()
                 val jsonNode = objectMapper.readTree(jsonString)
@@ -302,6 +311,7 @@ class RemoteCredentialsHandler(
                     jsonNode["private_key"]?.stringValue()!!,
                 )
             }
+
             "ssh" -> {
                 val jsonString = data.toStringUtf8()
                 val jsonNode = objectMapper.readTree(jsonString)
@@ -311,7 +321,10 @@ class RemoteCredentialsHandler(
                     jsonNode["public_key_fingerprint"]?.stringValue(),
                 )
             }
-            else -> throw Exception()
+
+            else -> {
+                throw Exception()
+            }
         }
 
     internal fun createByteStringFromData(
@@ -349,12 +362,14 @@ class RemoteCredentialsHandler(
                     )
                 ByteString.copyFromUtf8(json)
             }
+
             "json" -> {
                 val jsonCredentialValue = data as JsonCredentialValue
                 val value: JsonNode = jsonCredentialValue.value
                 val valueString = value.toString()
                 ByteString.copyFromUtf8(valueString)
             }
+
             "user" -> {
                 val userCredentialValue = data as UserCredentialValue
 
@@ -368,6 +383,7 @@ class RemoteCredentialsHandler(
                     )
                 ByteString.copyFromUtf8(json)
             }
+
             "rsa" -> {
                 val rsaCredentialValue = data as RsaCredentialValue
 
@@ -380,6 +396,7 @@ class RemoteCredentialsHandler(
                     )
                 ByteString.copyFromUtf8(json)
             }
+
             "ssh" -> {
                 val sshCredentialValue = data as SshCredentialValue
 
@@ -393,7 +410,10 @@ class RemoteCredentialsHandler(
                     )
                 ByteString.copyFromUtf8(json)
             }
-            else -> throw Exception()
+
+            else -> {
+                throw Exception()
+            }
         }
 
     internal fun createByteStringFromGenerationParameters(
@@ -492,7 +512,9 @@ class RemoteCredentialsHandler(
                 ByteString.copyFromUtf8(json)
             }
 
-            else -> throw Exception()
+            else -> {
+                throw Exception()
+            }
         }
 
     private fun getGenerationParametersFromResponse(
@@ -642,7 +664,9 @@ class RemoteCredentialsHandler(
                 CertificateGenerationParameters(generationRequestParameters)
             }
 
-            else -> throw Exception()
+            else -> {
+                throw Exception()
+            }
         }
     }
 

--- a/backends/remote/src/main/kotlin/org/cloudfoundry/credhub/remote/RemoteBackendClient.kt
+++ b/backends/remote/src/main/kotlin/org/cloudfoundry/credhub/remote/RemoteBackendClient.kt
@@ -319,11 +319,13 @@ class RemoteBackendClient(
                 channelType = EpollDomainSocketChannel::class.java
                 LOGGER.info("Using epoll for Netty transport.")
             }
+
             KQueue.isAvailable() -> {
                 group = KQueueEventLoopGroup()
                 channelType = KQueueDomainSocketChannel::class.java
                 LOGGER.info("Using KQueue for Netty transport.")
             }
+
             else -> {
                 throw RuntimeException("Unsupported OS '" + System.getProperty("os.name") + "', only Unix and Mac are supported")
             }

--- a/components/auth/src/main/kotlin/org/cloudfoundry/credhub/auth/UserContext.kt
+++ b/components/auth/src/main/kotlin/org/cloudfoundry/credhub/auth/UserContext.kt
@@ -34,9 +34,11 @@ class UserContext {
                     UAA_PASSWORD_GRANT_TYPE -> {
                         UAA_USER_ACTOR_PREFIX + ":" + this.userId
                     }
+
                     UAA_CLIENT_CREDENTIALS_GRANT_TYPE -> {
                         UAA_CLIENT_ACTOR_PREFIX + ":" + this.clientId
                     }
+
                     else -> {
                         throw UnsupportedGrantTypeException(this.grantType.toString())
                     }

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/data/CertificateMigration.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/data/CertificateMigration.kt
@@ -43,10 +43,13 @@ class CertificateMigration
         ) {
             var message = String.format("Unexpected exception reading certificate with name %s: %s", version.name, e.toString())
             when (e) {
-                is MalformedCertificateException ->
+                is MalformedCertificateException -> {
                     message = String.format("can't read certificate with name %s", version.name)
-                is MissingCertificateException ->
+                }
+
+                is MissingCertificateException -> {
                     message = String.format("missing certificate with name %s", version.name)
+                }
             }
             LOGGER.warn(message)
         }

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/domain/CredentialFactory.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/domain/CredentialFactory.kt
@@ -71,30 +71,50 @@ class CredentialFactory
         ): CredentialVersion {
             val credentialVersion =
                 when (type) {
-                    CredentialType.PASSWORD ->
+                    CredentialType.PASSWORD -> {
                         PasswordCredentialVersion(
                             credentialValue as StringCredentialValue?,
                             passwordGenerationParameters as StringGenerationParameters?,
                             encryptor,
                         )
-                    CredentialType.CERTIFICATE ->
+                    }
+
+                    CredentialType.CERTIFICATE -> {
                         CertificateCredentialVersion(
                             (credentialValue as CertificateCredentialValue?)!!,
                             name!!,
                             encryptor,
                         )
-                    CredentialType.VALUE -> ValueCredentialVersion(credentialValue as StringCredentialValue?, encryptor)
-                    CredentialType.RSA -> RsaCredentialVersion(credentialValue as RsaCredentialValue?, name!!, encryptor)
-                    CredentialType.SSH -> SshCredentialVersion(credentialValue as SshCredentialValue?, name!!, encryptor)
-                    CredentialType.JSON -> JsonCredentialVersion(credentialValue as JsonCredentialValue?, name!!, encryptor)
-                    CredentialType.USER ->
+                    }
+
+                    CredentialType.VALUE -> {
+                        ValueCredentialVersion(credentialValue as StringCredentialValue?, encryptor)
+                    }
+
+                    CredentialType.RSA -> {
+                        RsaCredentialVersion(credentialValue as RsaCredentialValue?, name!!, encryptor)
+                    }
+
+                    CredentialType.SSH -> {
+                        SshCredentialVersion(credentialValue as SshCredentialValue?, name!!, encryptor)
+                    }
+
+                    CredentialType.JSON -> {
+                        JsonCredentialVersion(credentialValue as JsonCredentialValue?, name!!, encryptor)
+                    }
+
+                    CredentialType.USER -> {
                         UserCredentialVersion(
                             credentialValue as UserCredentialValue?,
                             name!!,
                             passwordGenerationParameters as StringGenerationParameters?,
                             encryptor,
                         )
-                    else -> throw RuntimeException("Unrecognized type: $type")
+                    }
+
+                    else -> {
+                        throw RuntimeException("Unrecognized type: $type")
+                    }
                 }
             if (existingCredentialVersion == null) {
                 credentialVersion.createName(name!!)

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/requests/GenerateRequestTypeIdResolver.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/requests/GenerateRequestTypeIdResolver.kt
@@ -37,11 +37,26 @@ class GenerateRequestTypeIdResolver : TypeIdResolver {
         var subType: Class<*> = DefaultCredentialGenerateRequest::class.java
 
         when (id.lowercase()) {
-            CertificateCredentialVersionData.CREDENTIAL_TYPE -> subType = CertificateGenerateRequest::class.java
-            PasswordCredentialVersionData.CREDENTIAL_TYPE -> subType = PasswordGenerateRequest::class.java
-            RsaCredentialVersionData.CREDENTIAL_TYPE -> subType = RsaGenerateRequest::class.java
-            SshCredentialVersionData.CREDENTIAL_TYPE -> subType = SshGenerateRequest::class.java
-            UserCredentialVersionData.CREDENTIAL_TYPE -> subType = UserGenerateRequest::class.java
+            CertificateCredentialVersionData.CREDENTIAL_TYPE -> {
+                subType = CertificateGenerateRequest::class.java
+            }
+
+            PasswordCredentialVersionData.CREDENTIAL_TYPE -> {
+                subType = PasswordGenerateRequest::class.java
+            }
+
+            RsaCredentialVersionData.CREDENTIAL_TYPE -> {
+                subType = RsaGenerateRequest::class.java
+            }
+
+            SshCredentialVersionData.CREDENTIAL_TYPE -> {
+                subType = SshGenerateRequest::class.java
+            }
+
+            UserCredentialVersionData.CREDENTIAL_TYPE -> {
+                subType = UserGenerateRequest::class.java
+            }
+
             else -> {
             }
         }

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/requests/SetRequestTypeIdResolver.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/requests/SetRequestTypeIdResolver.kt
@@ -41,13 +41,34 @@ class SetRequestTypeIdResolver : TypeIdResolver {
         val lowerCaseId = id.lowercase()
 
         when (lowerCaseId) {
-            CertificateCredentialVersionData.CREDENTIAL_TYPE -> subType = CertificateSetRequest::class.java
-            ValueCredentialVersionData.CREDENTIAL_TYPE -> subType = ValueSetRequest::class.java
-            JsonCredentialVersionData.CREDENTIAL_TYPE -> subType = JsonSetRequest::class.java
-            PasswordCredentialVersionData.CREDENTIAL_TYPE -> subType = PasswordSetRequest::class.java
-            RsaCredentialVersionData.CREDENTIAL_TYPE -> subType = RsaSetRequest::class.java
-            SshCredentialVersionData.CREDENTIAL_TYPE -> subType = SshSetRequest::class.java
-            UserCredentialVersionData.CREDENTIAL_TYPE -> subType = UserSetRequest::class.java
+            CertificateCredentialVersionData.CREDENTIAL_TYPE -> {
+                subType = CertificateSetRequest::class.java
+            }
+
+            ValueCredentialVersionData.CREDENTIAL_TYPE -> {
+                subType = ValueSetRequest::class.java
+            }
+
+            JsonCredentialVersionData.CREDENTIAL_TYPE -> {
+                subType = JsonSetRequest::class.java
+            }
+
+            PasswordCredentialVersionData.CREDENTIAL_TYPE -> {
+                subType = PasswordSetRequest::class.java
+            }
+
+            RsaCredentialVersionData.CREDENTIAL_TYPE -> {
+                subType = RsaSetRequest::class.java
+            }
+
+            SshCredentialVersionData.CREDENTIAL_TYPE -> {
+                subType = SshSetRequest::class.java
+            }
+
+            UserCredentialVersionData.CREDENTIAL_TYPE -> {
+                subType = UserSetRequest::class.java
+            }
+
             else -> {
                 val message = String.format("Could not resolve type id '%s' into a subtype of %s", lowerCaseId, baseType)
                 throw InvalidTypeIdException(null, message, baseType, lowerCaseId)

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/services/CertificateDataService.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/services/CertificateDataService.kt
@@ -118,7 +118,13 @@ class CertificateDataService
 
                     UUID(high, low)
                 }
-                o.javaClass == UUID::class.java -> o as UUID
-                else -> throw IllegalArgumentException("Expected byte[] or UUID type. Received " + o.javaClass.toString())
+
+                o.javaClass == UUID::class.java -> {
+                    o as UUID
+                }
+
+                else -> {
+                    throw IllegalArgumentException("Expected byte[] or UUID type. Received " + o.javaClass.toString())
+                }
             }
     }

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/utils/PrivateKeyReader.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/utils/PrivateKeyReader.kt
@@ -30,15 +30,20 @@ class PrivateKeyReader private constructor() {
                     is DecoderException, is PEMException -> {
                         throw MalformedPrivateKeyException("Keys must be PEM-encoded PKCS#1 or unencrypted PKCS#8 keys.")
                     }
-                    else -> throw ex
+
+                    else -> {
+                        throw ex
+                    }
                 }
             }
 
             return when (parsed) {
                 // PKCS1
                 is PEMKeyPair -> JcaPEMKeyConverter().getPrivateKey(parsed.privateKeyInfo)
+
                 // PKCS8
                 is PrivateKeyInfo -> JcaPEMKeyConverter().getPrivateKey(parsed)
+
                 else -> throw MalformedPrivateKeyException("Key file is not in PKCS#1 or unencrypted PKCS#8 format")
             } as? RSAPrivateKey ?: throw MalformedPrivateKeyException("Key file does not contain an RSA private key")
         }

--- a/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/views/CredentialView.kt
+++ b/components/credentials/src/main/kotlin/org/cloudfoundry/credhub/views/CredentialView.kt
@@ -87,9 +87,11 @@ open class CredentialView {
                 is ValueCredentialVersion -> {
                     ValueView((credentialVersion as ValueCredentialVersion?)!!)
                 }
+
                 is PasswordCredentialVersion -> {
                     PasswordView(credentialVersion)
                 }
+
                 is CertificateCredentialVersion -> {
                     if (includeGenerationInfo) {
                         CertificateGenerationView(credentialVersion, concatenateCas)
@@ -97,18 +99,23 @@ open class CredentialView {
                         CertificateView(credentialVersion, concatenateCas)
                     }
                 }
+
                 is SshCredentialVersion -> {
                     SshView(credentialVersion)
                 }
+
                 is RsaCredentialVersion -> {
                     RsaView(credentialVersion)
                 }
+
                 is JsonCredentialVersion -> {
                     JsonView((credentialVersion as JsonCredentialVersion?)!!)
                 }
+
                 is UserCredentialVersion -> {
                     UserView(credentialVersion)
                 }
+
                 else -> {
                     throw IllegalArgumentException()
                 }

--- a/components/errors/src/main/kotlin/org/cloudfoundry/credhub/generate/ExceptionHandlers.kt
+++ b/components/errors/src/main/kotlin/org/cloudfoundry/credhub/generate/ExceptionHandlers.kt
@@ -151,8 +151,10 @@ class ExceptionHandlers {
         if (cause is UnrecognizedPropertyException) {
             return constructError(ErrorMessages.INVALID_JSON_KEY, cause.propertyName)
         } else if (cause is InvalidTypeIdException ||
-            cause is DatabindException &&
-            cause.message?.contains("missing property 'type'") == true
+            (
+                cause is DatabindException &&
+                    cause.message?.contains("missing property 'type'") == true
+            )
         ) {
             return constructError(ErrorMessages.INVALID_TYPE_WITH_SET_PROMPT)
         }
@@ -224,8 +226,10 @@ class ExceptionHandlers {
         if (cause is UnrecognizedPropertyException) {
             return constructError(ErrorMessages.INVALID_JSON_KEY, cause.propertyName)
         } else if (cause is InvalidTypeIdException ||
-            cause is DatabindException &&
-            cause.message?.contains("missing property 'type'") == true
+            (
+                cause is DatabindException &&
+                    cause.message?.contains("missing property 'type'") == true
+            )
         ) {
             return constructError(ErrorMessages.INVALID_TYPE_WITH_SET_PROMPT)
         } else if (cause is DatabindException) {


### PR DESCRIPTION
Compatible with versions 1.5.0 and 1.8.0 of ktlint

satisfies new rules introduced in 1.8.0:
- standard:blank-line-between-when-conditions
- standard:when-entry-bracing
- standard:mixed-condition-operators