### PR TITLE
bump: Java version to 25

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -16,6 +16,6 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'liberica'
-          java-version: '21'
+          java-version: '25'
       - name: Build and test with Gradle
         run: ./gradlew clean build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM bellsoft/liberica-openjdk-debian:21 AS build
+FROM bellsoft/liberica-openjdk-debian:25 AS build
 WORKDIR /app
 COPY . /app
 RUN ./gradlew bootJar -x test -x check
 
-FROM bellsoft/liberica-openjre-debian:21 AS run
+FROM bellsoft/liberica-openjre-debian:25 AS run
 WORKDIR /app
 COPY \
   --from=build \

--- a/build.gradle
+++ b/build.gradle
@@ -82,4 +82,4 @@ subprojects {
 ext['kotlin.version'] = "${kotlinVersion}"
 ext['protobuf-java.version'] = "${protobufVersion}"
 
-assert JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)
+assert JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_25)


### PR DESCRIPTION
This change needs to be coordinated with https://github.com/pivotal/credhub-release/pull/439 and credhub-oss-ci change.