### PR TITLE
docs: update Java and BouncyCastle versions in security FAQ

### DIFF
--- a/docs/credhub-security-faq.md
+++ b/docs/credhub-security-faq.md
@@ -11,8 +11,8 @@ https://docs.pivotal.io/pivotalcf/2-6/security/index.html
 ## What cryptographic libraries are in place?
 
 * Java JCA/JCE
-* Java 21 javax.crypto
-* bouncycastle FIPS 1.0
+* Java 25 javax.crypto
+* bouncycastle FIPS 2
 * OpenSSL on the stemcell
 
 ## What reliability and availability characteristics exist?


### PR DESCRIPTION
- Bump Java version reference from 21 to 25 in javax.crypto entry
- Update BouncyCastle FIPS version from 1.0 to 2 (current major)

ai-assisted=yes
TNZ-71585