### PR TITLE
fix: percent-encoded path bypass of ManagementInterceptor loopback gate

### DIFF
--- a/components/management/src/main/kotlin/org/cloudfoundry/credhub/ManagementInterceptor.kt
+++ b/components/management/src/main/kotlin/org/cloudfoundry/credhub/ManagementInterceptor.kt
@@ -7,6 +7,8 @@ import org.cloudfoundry.credhub.exceptions.ReadOnlyException
 import org.springframework.stereotype.Component
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.servlet.AsyncHandlerInterceptor
+import org.springframework.web.util.UriUtils
+import java.nio.charset.StandardCharsets
 
 @Component
 class ManagementInterceptor(
@@ -17,14 +19,28 @@ class ManagementInterceptor(
         response: HttpServletResponse,
         handler: Any,
     ): Boolean {
-        if (request.requestURI == MANAGEMENT_API && request.remoteAddr != request.localAddr) {
+        // Decode the raw requestURI so that percent-encoded paths like /%6Danagement are
+        // normalised to /management before comparison — mirroring exactly what Tomcat's
+        // CoyoteAdapter does via UDecoder.convert() when populating servletPath, and
+        // consistent with how Spring Security's PathPatternRequestMatcher and Spring MVC's
+        // handler mapping both resolve the effective path from the decoded form.
+        // Using requestURI (rather than servletPath) also works in MockMvc, where the
+        // servlet container never populates servletPath and it stays as "".
+        val contextPath = request.contextPath ?: ""
+        val decodedPath =
+            UriUtils.decode(
+                request.requestURI.removePrefix(contextPath),
+                StandardCharsets.UTF_8,
+            )
+
+        if (decodedPath == MANAGEMENT_API && request.remoteAddr != request.localAddr) {
             throw InvalidRemoteAddressException()
         }
 
         if (managementRegistry.readOnlyMode &&
             !request.method.equals(RequestMethod.GET.toString(), ignoreCase = true) &&
-            request.requestURI != MANAGEMENT_API &&
-            request.requestURI != INTERPOLATE_API
+            decodedPath != MANAGEMENT_API &&
+            decodedPath != INTERPOLATE_API
         ) {
             throw ReadOnlyException()
         }

--- a/components/management/src/test/kotlin/org/cloudfoundry/credhub/interceptors/ManagementInterceptorTest.kt
+++ b/components/management/src/test/kotlin/org/cloudfoundry/credhub/interceptors/ManagementInterceptorTest.kt
@@ -94,4 +94,22 @@ class ManagementInterceptorTest {
         request!!.method = "POST"
         subject!!.preHandle(request!!, response!!, Any())
     }
+
+    @Test
+    fun preHandle_throwsExceptionForEncodedManagementPathFromRemoteAddress() {
+        request!!.remoteAddr = "10.0.0.1"
+        request!!.localAddr = "127.0.0.1"
+        request!!.requestURI = "/%6Danagement"
+        assertThrows<InvalidRemoteAddressException> {
+            subject!!.preHandle(request!!, response!!, Any())
+        }
+    }
+
+    @Test
+    fun preHandle_encodedInterpolatePathIsExemptFromReadOnlyMode() {
+        managementRegistry!!.readOnlyMode = true
+        request!!.requestURI = "/%69nterpolate"
+        request!!.method = "POST"
+        subject!!.preHandle(request!!, response!!, Any())
+    }
 }


### PR DESCRIPTION
- A request to /%6Danagement (or any other percent-encoded equivalent) has requestURI = "/%6Danagement", which is not string-equal to "/management", so the loopback check was silently skipped
- Spring Security's PathPatternRequestMatcher and Tomcat's servlet mapping both operate on the decoded path, so the request was still permitted and dispatched to ManagementController.updateManagementRegistry(), allowing an unauthenticated remote caller to toggle CredHub's read-only mode
- Fix: decode requestURI with UriUtils.decode() (stripping context path first) before any comparison, mirroring what Tomcat's CoyoteAdapter.UDecoder does when producing servletPath; this works in both production (Tomcat decodes) and MockMvc tests (requestURI is always set, servletPath is not)
- Apply the same decoded path variable to the read-only mode exemption checks for /management and /interpolate so encoded variants of those paths are also correctly handled

ai-assisted=yes
TNZGOV-4101