### PR TITLE
feat: default timeout for JUnit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,11 @@ subprojects {
         }
         tasks.withType(Test) {
             useJUnitPlatform()
+            // Apply a default per-test-method timeout to every test that doesn't already have
+            // @Timeout. This converts a silent hang into a FAILED test with a stack trace,
+            // regardless of which database profile is active. Tests that legitimately need longer
+            // must declare an explicit @Timeout(N) annotation.
+            systemProperty 'junit.jupiter.execution.timeout.default', '60 s'
         }
     }
 }


### PR DESCRIPTION
- Set the default timeout for JUnit tests so tests can time out instead of hanging.
- Hopefully, it resolves the occasional unit test script hangs in Concourse.
- References: https://docs.junit.org/5.14.4/writing-tests/timeouts.html https://docs.junit.org/5.14.4/running-tests/configuration-parameters.html

ai-assisted=yes
TNZ-115123